### PR TITLE
DCNG-874 Use curl to ping ingress URI until we get a sensible response

### DIFF
--- a/src/test/config/bitbucket/helm_parameters
+++ b/src/test/config/bitbucket/helm_parameters
@@ -10,3 +10,5 @@ LOG_DOWNLOAD_DIR=${project.build.directory}/logs
 TARGET_NAMESPACE=${kubernetes.target.namespace}
 DOCKER_IMAGE_REGISTRY=${dockerImage.registry}
 DOCKER_IMAGE_VERSION=${dockerImage.version}
+INGRESS_DOMAIN_KITT=${kitt.ingress.domain}
+INGRESS_DOMAIN_EKS=${eks.ingress.domain}

--- a/src/test/config/confluence/helm_parameters
+++ b/src/test/config/confluence/helm_parameters
@@ -10,3 +10,5 @@ LOG_DOWNLOAD_DIR=${project.build.directory}/logs
 TARGET_NAMESPACE=${kubernetes.target.namespace}
 DOCKER_IMAGE_REGISTRY=${dockerImage.registry}
 DOCKER_IMAGE_VERSION=${dockerImage.version}
+INGRESS_DOMAIN_KITT=${kitt.ingress.domain}
+INGRESS_DOMAIN_EKS=${eks.ingress.domain}

--- a/src/test/config/confluence/ingress-KITT.yaml
+++ b/src/test/config/confluence/ingress-KITT.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.io/ingress.class: "ingress-internal-01"
 spec:
   virtualhost:
-    fqdn: ${HELM_RELEASE_NAME}.${kubernetes.ingress.domain}
+    fqdn: ${HELM_RELEASE_NAME}.${kitt.ingress.domain}
   routes:
     - conditions:
         - prefix: /

--- a/src/test/config/jira/helm_parameters
+++ b/src/test/config/jira/helm_parameters
@@ -10,3 +10,5 @@ LOG_DOWNLOAD_DIR=${project.build.directory}/logs
 TARGET_NAMESPACE=${kubernetes.target.namespace}
 DOCKER_IMAGE_REGISTRY=${dockerImage.registry}
 DOCKER_IMAGE_VERSION=${dockerImage.version}
+INGRESS_DOMAIN_KITT=${kitt.ingress.domain}
+INGRESS_DOMAIN_EKS=${eks.ingress.domain}

--- a/src/test/config/jira/ingress-KITT.yaml
+++ b/src/test/config/jira/ingress-KITT.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.io/ingress.class: "ingress-internal-01"
 spec:
   virtualhost:
-    fqdn: ${HELM_RELEASE_NAME}.${kubernetes.ingress.domain}
+    fqdn: ${HELM_RELEASE_NAME}.${kitt.ingress.domain}
   routes:
     - conditions:
         - prefix: /


### PR DESCRIPTION
Adds a bit more to the `helm_install.sh` script so that we use `curl` to verify that the Ingress is returning a non-zero response.

This should rule out one source of build flakiness whereby we try to talk to the product before the ingress is ready.