### PR TITLE
Add ServiceAccount and ClusterRole to Confluence chart

### DIFF
--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -48,6 +48,50 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+The name of the service account to be used.
+If the name is defined in the chart values, then use that,
+else if we're creating a new service account then use the name of the Helm release,
+else just use the "default" service account.
+*/}}
+{{- define "confluence.serviceAccountName" -}}
+{{- if .Values.serviceAccount.name }}
+{{- .Values.serviceAccount.name }}
+{{- else }}
+{{- if .Values.serviceAccount.create }}
+{{- include "confluence.fullname" . -}}
+{{ else }}
+default
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+The name of the ClusterRole that will be created.
+If the name is defined in the chart values, then use that,
+else use the name of the Helm release.
+*/}}
+{{- define "confluence.clusterRoleName" -}}
+{{- if .Values.serviceAccount.clusterRole.name }}
+{{- .Values.serviceAccount.clusterRole.name }}
+{{- else }}
+{{- include "confluence.fullname" . -}}
+{{- end }}
+{{- end }}
+
+{{/*
+The name of the ClusterRoleBinding that will be created.
+If the name is defined in the chart values, then use that,
+else use the name of the ClusterRole.
+*/}}
+{{- define "confluence.clusterRoleBindingName" -}}
+{{- if .Values.serviceAccount.clusterRoleBinding.name }}
+{{- .Values.serviceAccount.clusterRoleBinding.name }}
+{{- else }}
+{{- include "confluence.clusterRoleName" . -}}
+{{- end }}
+{{- end }}
+
+{{/*
 These labels will be applied to all Confluence (non-Synchrony) resources in the chart
 */}}
 {{- define "confluence.labels" -}}

--- a/src/main/charts/confluence/templates/clusterrole.yaml
+++ b/src/main/charts/confluence/templates/clusterrole.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceAccount.clusterRole.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "confluence.clusterRoleName" . }}
+  labels:
+  {{- include "confluence.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+{{- end -}}

--- a/src/main/charts/confluence/templates/clusterrolebinding.yaml
+++ b/src/main/charts/confluence/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.clusterRoleBinding.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "confluence.clusterRoleBindingName" . }}
+  labels:
+  {{- include "confluence.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "confluence.clusterRoleName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "confluence.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/src/main/charts/confluence/templates/serviceaccount.yaml
+++ b/src/main/charts/confluence/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "confluence.serviceAccountName" . }}
+  labels:
+  {{- include "confluence.labels" . | nindent 4 }}
+{{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end -}}
+{{- end -}}

--- a/src/main/charts/confluence/templates/statefulset-synchrony.yaml
+++ b/src/main/charts/confluence/templates/statefulset-synchrony.yaml
@@ -19,9 +19,7 @@ spec:
       labels:
         {{- include "synchrony.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if .Values.serviceAccountName }}
-      serviceAccountName: {{ .Values.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ include "confluence.serviceAccountName" . }}
       terminationGracePeriodSeconds: 1
       containers:
         - name: synchrony

--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -19,9 +19,7 @@ spec:
       labels:
         {{- include "confluence.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if .Values.serviceAccountName }}
-      serviceAccountName: {{ .Values.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ include "confluence.serviceAccountName" . }}
       terminationGracePeriodSeconds: 1
       securityContext:
         # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Cnfluence container.

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -9,8 +9,27 @@ image:
   # -- The docker image tag to be used. Defaults to the Chart appVersion.
   tag:
 
-# -- Specifies which serviceAccount to use for the pods. If not specified, the kubernetes default will be used.
-serviceAccountName:
+serviceAccount:
+  # -- Specifies the name of the ServiceAccount to be used by the pods.
+  # If not specified, but the the "serviceAccount.create" flag is set, then the ServiceAccount name will be auto-generated,
+  # otherwise the 'default' ServiceAccount will be used.
+  name:
+  # -- true if a ServiceAccount should be created, or false if it already exists
+  create: true
+  # -- The list of image pull secrets that should be added to the created ServiceAccount
+  imagePullSecrets: []
+  clusterRole:
+    # -- Specifies the name of the ClusterRole that will be created if the "serviceAccount.clusterRole.create" flag is set.
+    # If not specified, a name will be auto-generated.
+    name:
+    # -- true if a ClusterRole should be created, or false if it already exists
+    create: true
+  clusterRoleBinding:
+    # -- Specifies the name of the ClusterRoleBinding that will be created if the "serviceAccount.clusterRoleBinding.create" flag is set
+    # If not specified, a name will be auto-generated.
+    name:
+    # -- true if a ClusterRoleBinding should be created, or false if it already exists
+    create: true
 
 database:
   # -- The type of database being used.

--- a/src/test/config/confluence/values-EKS.yaml
+++ b/src/test/config/confluence/values-EKS.yaml
@@ -1,0 +1,14 @@
+# This file contains overrides for the Confluence Helm chart's values.yaml file
+
+# The created service account needs to have the credentials to pull from the Atlassian docker registry
+serviceAccount:
+  imagePullSecrets:
+    - name: regcred
+
+synchrony:
+  ingressUrl: https://${helm.release.prefix}-confluence.${eks.ingress.domain}/synchrony
+
+volumes:
+  sharedHome:
+    volumeClaimName: efs-claim # Pre-provisioned, and shared by all of our pods
+    subPath: ${helm.release.prefix}-confluence # Since all of our pods share the same EFS PV, we use subpath mounts to prevent interference

--- a/src/test/config/confluence/values-KITT.yaml
+++ b/src/test/config/confluence/values-KITT.yaml
@@ -1,0 +1,22 @@
+# This file contains overrides for the Confluence Helm chart's values.yaml file
+
+# Use the pre-created service account and role binding provided by KITT.
+serviceAccount:
+  name: "namespace-admin"
+  create: false
+  clusterRole:
+    create: false
+  clusterRoleBinding:
+    create: false
+
+# KITT requires these annotations on all pods
+podAnnotations:
+  "atlassian.com/business_unit": "server_engineering"
+
+synchrony:
+  ingressUrl: https://${helm.release.prefix}-confluence.${kitt.ingress.domain}/synchrony
+
+volumes:
+  sharedHome:
+    volumeClaimName: efs-claim # Pre-provisioned by KITT, and shared by all of our pods
+    subPath: ${helm.release.prefix}-confluence # Since all of our pods share the same EFS PV, we use subpath mounts to prevent interference

--- a/src/test/config/confluence/values.yaml
+++ b/src/test/config/confluence/values.yaml
@@ -1,12 +1,5 @@
 # This file contains overrides for the Confluence Helm chart's values.yaml file
 
-# The service account name used in the dcng namespace of the KITT cluster
-serviceAccountName: "namespace-admin"
-
-# KITT requires these annotations on all pods
-podAnnotations:
-  "atlassian.com/business_unit": "server_engineering"
-
 confluence:
   resources:
     container:
@@ -16,11 +9,3 @@ confluence:
 database:
   type: postgresql
   url: jdbc:postgresql://${helm.release.prefix}-confluence-pgsql:5432/confluence
-
-synchrony:
-  ingressUrl: https://${helm.release.prefix}-confluence.${kubernetes.ingress.domain}/synchrony
-
-volumes:
-  sharedHome:
-    volumeClaimName: efs-claim # Pre-provisioned by KITT, and shared by all of our pods
-    subPath: ${helm.release.prefix}-confluence # Since all of our pods share the same EFS PV, we use subpath mounts to prevent interference

--- a/src/test/java/test/HelmOutputComparisonTest.java
+++ b/src/test/java/test/HelmOutputComparisonTest.java
@@ -47,6 +47,7 @@ class HelmOutputComparisonTest {
                         getHelmReleaseName(product),
                         getHelmChartPath(product).toString(),
                         "--debug",
+                        "-n mynamespace",
                         "--values",
                         getHelmValuesFile(product).toString())
                 .redirectOutput(outputFile.toFile())

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -1,4 +1,17 @@
 ---
+# Source: confluence/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: unittest-confluence
+  labels:
+    helm.sh/chart: confluence-0.1.0
+    app.kubernetes.io/name: confluence
+    app.kubernetes.io/instance: unittest-confluence
+    app.kubernetes.io/version: "7.9.0-jdk11"
+    app.kubernetes.io/managed-by: Helm
+    label1: value1
+---
 # Source: confluence/templates/config-jvm.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -36,6 +49,50 @@ data:
        -classpath /opt/atlassian/confluence/confluence/WEB-INF/packages/synchrony-standalone.jar:/opt/atlassian/confluence/confluence/WEB-INF/lib/* \
        synchrony.core \
        sql
+---
+# Source: confluence/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: unittest-confluence
+  labels:
+    helm.sh/chart: confluence-0.1.0
+    app.kubernetes.io/name: confluence
+    app.kubernetes.io/instance: unittest-confluence
+    app.kubernetes.io/version: "7.9.0-jdk11"
+    app.kubernetes.io/managed-by: Helm
+    label1: value1
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+---
+# Source: confluence/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: unittest-confluence
+  labels:
+    helm.sh/chart: confluence-0.1.0
+    app.kubernetes.io/name: confluence
+    app.kubernetes.io/instance: unittest-confluence
+    app.kubernetes.io/version: "7.9.0-jdk11"
+    app.kubernetes.io/managed-by: Helm
+    label1: value1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: unittest-confluence
+subjects:
+  - kind: ServiceAccount
+    name: unittest-confluence
+    namespace:  mynamespace
 ---
 # Source: confluence/templates/service-synchrony.yaml
 apiVersion: v1
@@ -116,6 +173,7 @@ spec:
         app.kubernetes.io/name: confluence-synchrony
         app.kubernetes.io/instance: unittest-confluence
     spec:
+      serviceAccountName: unittest-confluence
       terminationGracePeriodSeconds: 1
       containers:
         - name: synchrony
@@ -197,6 +255,7 @@ spec:
         app.kubernetes.io/name: confluence
         app.kubernetes.io/instance: unittest-confluence
     spec:
+      serviceAccountName: unittest-confluence
       terminationGracePeriodSeconds: 1
       securityContext:
         # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Cnfluence container.


### PR DESCRIPTION
Currently, our Helm charts requires the customer to pre-configure a `ServiceAccount`, `ClusterRole` and `ClusterRoleBinding`. In the case of Confluence and Bitbucket, this requires very specific role permissions in order for peer discovery to work, and this isn't really something we want customers to have to do.

So I've added those 3 resources to the Confluence Helm chart, with corresponding entries in `values.yaml` to control how they get expressed. By default, all 3 will be created automatically, with generated names, but the customer can pick their own names, or disable their creation entirely.

I've also changed the `values.yaml` that we use for EKS so that we *do* use the generated `ServiceAccount`, `ClusterRole` and `ClusterRoleBinding`, so that we exercise this part of the chart in our tests.

For KITT, we need to keep using the current approach of using the pre-defined service account, since we have no permissions to create a new one.

See #18 doing the same thing for Jira