### PR TITLE
DCNG-894 Add a ServiceAccount to the Jira chart

### DIFF
--- a/src/main/charts/jira/templates/_helpers.tpl
+++ b/src/main/charts/jira/templates/_helpers.tpl
@@ -34,6 +34,24 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+The name of the service account to be used.
+If the name is defined in the chart values, then use that,
+else if we're creating a new service account then use the name of the Helm release,
+else just use the "default" service account.
+*/}}
+{{- define "jira.serviceAccountName" -}}
+{{- if .Values.serviceAccount.name }}
+{{- .Values.serviceAccount.name }}
+{{- else }}
+{{- if .Values.serviceAccount.create }}
+{{- include "jira.fullname" . -}}
+{{ else }}
+default
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "jira.labels" -}}

--- a/src/main/charts/jira/templates/serviceaccount.yaml
+++ b/src/main/charts/jira/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "jira.serviceAccountName" . }}
+  labels:
+  {{- include "jira.labels" . | nindent 4 }}
+{{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end -}}
+{{- end -}}

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -19,9 +19,7 @@ spec:
       labels:
         {{- include "jira.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if .Values.serviceAccountName }}
-      serviceAccountName: {{ .Values.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ include "jira.serviceAccountName" . }}
       terminationGracePeriodSeconds: 1
       securityContext:
         # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Jira container.

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -9,8 +9,15 @@ image:
   # -- The docker image tag to be used. Defaults to the Chart appVersion.
   tag: ""
 
-# -- Specifies which serviceAccount to use for the pods. If not specified, the kubernetes default will be used.
-serviceAccountName:
+serviceAccount:
+  # -- Specifies the name of the ServiceAccount to be used by the pods.
+  # If not specified, but the the "serviceAccount.create" flag is set, then the ServiceAccount name will be auto-generated,
+  # otherwise the 'default' ServiceAccount will be used.
+  name:
+  # -- true if a ServiceAccount should be created, or false if it already exists
+  create: true
+  # -- The list of image pull secrets that should be added to the created ServiceAccount
+  imagePullSecrets: []
 
 database:
   # -- The type of database being used.

--- a/src/test/config/jira/values-EKS.yaml
+++ b/src/test/config/jira/values-EKS.yaml
@@ -1,0 +1,11 @@
+# This file contains overrides for the Jira Helm chart's values.yaml file
+
+# The created service account needs to have the credentials to pull from the Atlassian docker registry
+serviceAccount:
+  imagePullSecrets:
+    - name: regcred
+
+volumes:
+  sharedHome:
+    volumeClaimName: efs-claim # Pre-provisioned, and shared by all of our pods
+    subPath: ${helm.release.prefix}-jira # Since all of our pods share the same EFS PV, we use subpath mounts to prevent interference

--- a/src/test/config/jira/values-KITT.yaml
+++ b/src/test/config/jira/values-KITT.yaml
@@ -1,0 +1,19 @@
+# This file contains overrides for the Jira Helm chart's values.yaml file
+
+# Use the pre-created service account and role binding provided by KITT.
+serviceAccount:
+  name: "namespace-admin"
+  create: false
+  clusterRole:
+    create: false
+  clusterRoleBinding:
+    create: false
+
+# KITT requires these annotations on all pods
+podAnnotations:
+  "atlassian.com/business_unit": "server_engineering"
+
+volumes:
+  sharedHome:
+    volumeClaimName: efs-claim # Pre-provisioned by KITT, and shared by all of our pods
+    subPath: ${helm.release.prefix}-jira # Since all of our pods share the same EFS PV, we use subpath mounts to prevent interference

--- a/src/test/config/jira/values.yaml
+++ b/src/test/config/jira/values.yaml
@@ -1,12 +1,5 @@
 # This file contains overrides for the Jira Helm chart's values.yaml file
 
-# The service account name used in the dcng namespace of the KITT cluster
-serviceAccountName: "namespace-admin"
-
-# KITT requires these annotations on all pods
-podAnnotations:
-  "atlassian.com/business_unit": "server_engineering"
-
 jira:
   additionalJvmArgs:
     - -Datlassian.darkfeature.jira.onboarding.feature.disabled=true
@@ -21,8 +14,3 @@ database:
   type: postgres72
   url: jdbc:postgresql://${helm.release.prefix}-jira-pgsql:5432/jira
   driver: org.postgresql.Driver
-
-volumes:
-  sharedHome:
-    volumeClaimName: efs-claim # Pre-provisioned by KITT, and shared by all of our pods
-    subPath: ${helm.release.prefix}-jira # Since all of our pods share the same EFS PV, we use subpath mounts to prevent interference

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -1,4 +1,17 @@
 ---
+# Source: jira/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: unittest-jira
+  labels:
+    helm.sh/chart: jira-0.1.0
+    app.kubernetes.io/name: jira
+    app.kubernetes.io/instance: unittest-jira
+    app.kubernetes.io/version: "8.13.0-jdk11"
+    app.kubernetes.io/managed-by: Helm
+    label1: value1
+---
 # Source: jira/templates/config-jvm.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -65,6 +78,7 @@ spec:
         app.kubernetes.io/name: jira
         app.kubernetes.io/instance: unittest-jira
     spec:
+      serviceAccountName: unittest-jira
       terminationGracePeriodSeconds: 1
       securityContext:
         # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Jira container.


### PR DESCRIPTION
This is similar to #17 which adds a `ServiceAccount` to the Confluence chart, but this time for Jira.

Note that it's simpler for Jira, with No `ClusterRole` or `ClusterRoleBinding`, since Jira does not talk to the Kubernetes API and does not need special permissions. We still need a `ServiceAccount` as a place to attach the image pull credentials, though.