### PR TITLE
Add ServiceAccount/ClusterRole[Binding] to Bitbucket chart

### DIFF
--- a/src/main/charts/bitbucket/templates/_helpers.tpl
+++ b/src/main/charts/bitbucket/templates/_helpers.tpl
@@ -35,6 +35,50 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+The name of the service account to be used.
+If the name is defined in the chart values, then use that,
+else if we're creating a new service account then use the name of the Helm release,
+else just use the "default" service account.
+*/}}
+{{- define "bitbucket.serviceAccountName" -}}
+{{- if .Values.serviceAccount.name }}
+{{- .Values.serviceAccount.name }}
+{{- else }}
+{{- if .Values.serviceAccount.create }}
+{{- include "bitbucket.fullname" . -}}
+{{ else }}
+default
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+The name of the ClusterRole that will be created.
+If the name is defined in the chart values, then use that,
+else use the name of the Helm release.
+*/}}
+{{- define "bitbucket.clusterRoleName" -}}
+{{- if .Values.serviceAccount.clusterRole.name }}
+{{- .Values.serviceAccount.clusterRole.name }}
+{{- else }}
+{{- include "bitbucket.fullname" . -}}
+{{- end }}
+{{- end }}
+
+{{/*
+The name of the ClusterRoleBinding that will be created.
+If the name is defined in the chart values, then use that,
+else use the name of the ClusterRole.
+*/}}
+{{- define "bitbucket.clusterRoleBindingName" -}}
+{{- if .Values.serviceAccount.clusterRoleBinding.name }}
+{{- .Values.serviceAccount.clusterRoleBinding.name }}
+{{- else }}
+{{- include "bitbucket.clusterRoleName" . -}}
+{{- end }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "bitbucket.labels" -}}

--- a/src/main/charts/bitbucket/templates/clusterrole.yaml
+++ b/src/main/charts/bitbucket/templates/clusterrole.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceAccount.clusterRole.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "bitbucket.clusterRoleName" . }}
+  labels:
+  {{- include "bitbucket.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+{{- end -}}

--- a/src/main/charts/bitbucket/templates/clusterrolebinding.yaml
+++ b/src/main/charts/bitbucket/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.clusterRoleBinding.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "bitbucket.clusterRoleBindingName" . }}
+  labels:
+  {{- include "bitbucket.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "bitbucket.clusterRoleName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "bitbucket.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/src/main/charts/bitbucket/templates/serviceaccount.yaml
+++ b/src/main/charts/bitbucket/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "bitbucket.serviceAccountName" . }}
+  labels:
+  {{- include "bitbucket.labels" . | nindent 4 }}
+{{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end -}}
+{{- end -}}

--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -20,9 +20,7 @@ spec:
       labels:
         {{- include "bitbucket.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if .Values.serviceAccountName }}
-      serviceAccountName: {{ .Values.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ include "bitbucket.serviceAccountName" . }}
       terminationGracePeriodSeconds: 1
       securityContext:
         # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Bitbucket container.

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -7,8 +7,27 @@ image:
   # -- The docker image tag to be used. Defaults to the Chart appVersion.
   tag: ""
 
-# -- Specifies which serviceAccount to use for the pods. If not specified, the kubernetes default will be used.
-serviceAccountName:
+serviceAccount:
+  # -- Specifies the name of the ServiceAccount to be used by the pods.
+  # If not specified, but the the "serviceAccount.create" flag is set, then the ServiceAccount name will be auto-generated,
+  # otherwise the 'default' ServiceAccount will be used.
+  name:
+  # -- true if a ServiceAccount should be created, or false if it already exists
+  create: true
+  # -- The list of image pull secrets that should be added to the created ServiceAccount
+  imagePullSecrets: []
+  clusterRole:
+    # -- Specifies the name of the ClusterRole that will be created if the "serviceAccount.clusterRole.create" flag is set.
+    # If not specified, a name will be auto-generated.
+    name:
+    # -- true if a ClusterRole should be created, or false if it already exists
+    create: true
+  clusterRoleBinding:
+    # -- Specifies the name of the ClusterRoleBinding that will be created if the "serviceAccount.clusterRoleBinding.create" flag is set
+    # If not specified, a name will be auto-generated.
+    name:
+    # -- true if a ClusterRoleBinding should be created, or false if it already exists
+    create: true
 
 database:
   # -- The JDBC URL of the database to be used by Bitbucket, e.g. jdbc:postgresql://host:port/database

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -19,7 +19,9 @@ spec:
       labels:
         {{- include "jira.selectorLabels" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ include "jira.serviceAccountName" . }}
+      {{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
       terminationGracePeriodSeconds: 1
       securityContext:
         # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Jira container.

--- a/src/test/config/bitbucket/values-CUSTOM.yaml
+++ b/src/test/config/bitbucket/values-CUSTOM.yaml
@@ -1,3 +1,0 @@
-bitbucket:
-  proxy:
-    fqdn: ${helm.release.prefix}-bitbucket.${kubernetes.ingress.domain}

--- a/src/test/config/bitbucket/values-EKS.yaml
+++ b/src/test/config/bitbucket/values-EKS.yaml
@@ -1,3 +1,13 @@
+# The created service account needs to have the credentials to pull from the Atlassian docker registry
+serviceAccount:
+  imagePullSecrets:
+    - name: regcred
+
 bitbucket:
   proxy:
     fqdn: ${helm.release.prefix}-bitbucket.${eks.ingress.domain}
+
+volumes:
+  sharedHome:
+    volumeClaimName: efs-claim # Pre-provisioned by KITT, and shared by all of our pods
+    subPath: ${helm.release.prefix}-bitbucket # Since all of our pods share the same EFS PV, we use subpath mounts to prevent interference

--- a/src/test/config/bitbucket/values-KITT.yaml
+++ b/src/test/config/bitbucket/values-KITT.yaml
@@ -1,3 +1,21 @@
+# Use the pre-created service account and role binding provided by KITT.
+serviceAccount:
+  name: "namespace-admin"
+  create: false
+  clusterRole:
+    create: false
+  clusterRoleBinding:
+    create: false
+
+# KITT requires these annotations on all pods
+podAnnotations:
+  "atlassian.com/business_unit": "server_engineering"
+
 bitbucket:
   proxy:
     fqdn: ${helm.release.prefix}-bitbucket.${kitt.ingress.domain}
+
+volumes:
+  sharedHome:
+    volumeClaimName: efs-claim # Pre-provisioned by KITT, and shared by all of our pods
+    subPath: ${helm.release.prefix}-bitbucket # Since all of our pods share the same EFS PV, we use subpath mounts to prevent interference

--- a/src/test/config/bitbucket/values.yaml
+++ b/src/test/config/bitbucket/values.yaml
@@ -1,12 +1,5 @@
 # This file contains overrides for the Bitbucket Helm chart's values.yaml file
 
-# The service account name used in the dcng namespace of the KITT cluster
-serviceAccountName: "namespace-admin"
-
-# KITT requires these annotations on all pods
-podAnnotations:
-  "atlassian.com/business_unit": "server_engineering"
-
 database:
   url: jdbc:postgresql://${helm.release.prefix}-bitbucket-pgsql:5432/bitbucket
   driver: org.postgresql.Driver
@@ -18,8 +11,3 @@ bitbucket:
     container:
       requests:
         memory: 2G
-
-volumes:
-  sharedHome:
-    volumeClaimName: efs-claim # Pre-provisioned by KITT, and shared by all of our pods
-    subPath: ${helm.release.prefix}-bitbucket # Since all of our pods share the same EFS PV, we use subpath mounts to prevent interference

--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -1,4 +1,17 @@
 ---
+# Source: bitbucket/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: unittest-bitbucket
+  labels:
+    helm.sh/chart: bitbucket-0.1.0
+    app.kubernetes.io/name: bitbucket
+    app.kubernetes.io/instance: unittest-bitbucket
+    app.kubernetes.io/version: "7.7.0-jdk11"
+    app.kubernetes.io/managed-by: Helm
+    label1: value1
+---
 # Source: bitbucket/templates/config-jvm.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -15,6 +28,50 @@ data:
   additional_jvm_args: >-
   max_heap: 1g
   min_heap: 1g
+---
+# Source: bitbucket/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: unittest-bitbucket
+  labels:
+    helm.sh/chart: bitbucket-0.1.0
+    app.kubernetes.io/name: bitbucket
+    app.kubernetes.io/instance: unittest-bitbucket
+    app.kubernetes.io/version: "7.7.0-jdk11"
+    app.kubernetes.io/managed-by: Helm
+    label1: value1
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+---
+# Source: bitbucket/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: unittest-bitbucket
+  labels:
+    helm.sh/chart: bitbucket-0.1.0
+    app.kubernetes.io/name: bitbucket
+    app.kubernetes.io/instance: unittest-bitbucket
+    app.kubernetes.io/version: "7.7.0-jdk11"
+    app.kubernetes.io/managed-by: Helm
+    label1: value1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: unittest-bitbucket
+subjects:
+  - kind: ServiceAccount
+    name: unittest-bitbucket
+    namespace:  mynamespace
 ---
 # Source: bitbucket/templates/service.yaml
 apiVersion: v1
@@ -72,6 +129,7 @@ spec:
         app.kubernetes.io/name: bitbucket
         app.kubernetes.io/instance: unittest-bitbucket
     spec:
+      serviceAccountName: unittest-bitbucket
       terminationGracePeriodSeconds: 1
       securityContext:
         # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Bitbucket container.

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -78,7 +78,6 @@ spec:
         app.kubernetes.io/name: jira
         app.kubernetes.io/instance: unittest-jira
     spec:
-      serviceAccountName: unittest-jira
       terminationGracePeriodSeconds: 1
       securityContext:
         # This is intended to ensure that the shared-home volume is group-writeable by the GID used by the Jira container.


### PR DESCRIPTION
Following on from #17 with Confluence and #18 with Jira, we now add a `ServiceAccount`, `ClusterRole` and `ClusterRoleBinding` for the Bitbucket chart, and as before, changing `values-EKS.yaml` so that we use the generated service account rather than the pre-created one.