### PR TITLE
DCNG-897 Add hook-delete-policy to chart tests and nfs-fixer job

### DIFF
--- a/src/main/charts/bitbucket/templates/nfs-permission-fixer.yaml
+++ b/src/main/charts/bitbucket/templates/nfs-permission-fixer.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "bitbucket.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     metadata:

--- a/src/main/charts/bitbucket/templates/nfs-permission-fixer.yaml
+++ b/src/main/charts/bitbucket/templates/nfs-permission-fixer.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "bitbucket.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
   template:
     metadata:

--- a/src/main/charts/bitbucket/templates/tests/test-application-status.yaml
+++ b/src/main/charts/bitbucket/templates/tests/test-application-status.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ include "bitbucket.fullname" . }}-application-status-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/bitbucket/templates/tests/test-application-status.yaml
+++ b/src/main/charts/bitbucket/templates/tests/test-application-status.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "{{ include "bitbucket.fullname" . }}-application-status-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/bitbucket/templates/tests/test-database-connectivity.yaml
+++ b/src/main/charts/bitbucket/templates/tests/test-database-connectivity.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ include "bitbucket.fullname" . }}-db-connectivity-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/bitbucket/templates/tests/test-database-connectivity.yaml
+++ b/src/main/charts/bitbucket/templates/tests/test-database-connectivity.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "{{ include "bitbucket.fullname" . }}-db-connectivity-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/bitbucket/templates/tests/test-required-values.yaml
+++ b/src/main/charts/bitbucket/templates/tests/test-required-values.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "{{ include "bitbucket.fullname" . }}-required-values-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/bitbucket/templates/tests/test-required-values.yaml
+++ b/src/main/charts/bitbucket/templates/tests/test-required-values.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ include "bitbucket.fullname" . }}-required-values-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/bitbucket/templates/tests/test-shared-home-permissions.yaml
+++ b/src/main/charts/bitbucket/templates/tests/test-shared-home-permissions.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "{{ include "bitbucket.fullname" . }}-shared-home-permissions-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/bitbucket/templates/tests/test-shared-home-permissions.yaml
+++ b/src/main/charts/bitbucket/templates/tests/test-shared-home-permissions.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ include "bitbucket.fullname" . }}-shared-home-permissions-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/confluence/templates/nfs-permission-fixer.yaml
+++ b/src/main/charts/confluence/templates/nfs-permission-fixer.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "confluence.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     metadata:

--- a/src/main/charts/confluence/templates/nfs-permission-fixer.yaml
+++ b/src/main/charts/confluence/templates/nfs-permission-fixer.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "confluence.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
   template:
     metadata:

--- a/src/main/charts/confluence/templates/tests/test-application-status.yaml
+++ b/src/main/charts/confluence/templates/tests/test-application-status.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "{{ include "confluence.fullname" . }}-application-status-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/confluence/templates/tests/test-application-status.yaml
+++ b/src/main/charts/confluence/templates/tests/test-application-status.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ include "confluence.fullname" . }}-application-status-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/confluence/templates/tests/test-database-connectivity.yaml
+++ b/src/main/charts/confluence/templates/tests/test-database-connectivity.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ include "confluence.fullname" . }}-db-connectivity-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/confluence/templates/tests/test-database-connectivity.yaml
+++ b/src/main/charts/confluence/templates/tests/test-database-connectivity.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "{{ include "confluence.fullname" . }}-db-connectivity-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/confluence/templates/tests/test-required-values.yaml
+++ b/src/main/charts/confluence/templates/tests/test-required-values.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ include "confluence.fullname" . }}-required-values-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/confluence/templates/tests/test-required-values.yaml
+++ b/src/main/charts/confluence/templates/tests/test-required-values.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "{{ include "confluence.fullname" . }}-required-values-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/confluence/templates/tests/test-shared-home-permissions.yaml
+++ b/src/main/charts/confluence/templates/tests/test-shared-home-permissions.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "{{ include "confluence.fullname" . }}-shared-home-permissions-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/confluence/templates/tests/test-shared-home-permissions.yaml
+++ b/src/main/charts/confluence/templates/tests/test-shared-home-permissions.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ include "confluence.fullname" . }}-shared-home-permissions-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/jira/templates/nfs-permission-fixer.yaml
+++ b/src/main/charts/jira/templates/nfs-permission-fixer.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "jira.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
   template:
     metadata:

--- a/src/main/charts/jira/templates/nfs-permission-fixer.yaml
+++ b/src/main/charts/jira/templates/nfs-permission-fixer.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "jira.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     metadata:

--- a/src/main/charts/jira/templates/tests/test-application-status.yaml
+++ b/src/main/charts/jira/templates/tests/test-application-status.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ include "jira.fullname" . }}-application-status-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/jira/templates/tests/test-application-status.yaml
+++ b/src/main/charts/jira/templates/tests/test-application-status.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "{{ include "jira.fullname" . }}-application-status-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/jira/templates/tests/test-database-connectivity.yaml
+++ b/src/main/charts/jira/templates/tests/test-database-connectivity.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "{{ include "jira.fullname" . }}-db-connectivity-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/jira/templates/tests/test-database-connectivity.yaml
+++ b/src/main/charts/jira/templates/tests/test-database-connectivity.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ include "jira.fullname" . }}-db-connectivity-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/jira/templates/tests/test-required-values.yaml
+++ b/src/main/charts/jira/templates/tests/test-required-values.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ include "jira.fullname" . }}-required-values-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/jira/templates/tests/test-required-values.yaml
+++ b/src/main/charts/jira/templates/tests/test-required-values.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "{{ include "jira.fullname" . }}-required-values-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/jira/templates/tests/test-shared-home-permissions.yaml
+++ b/src/main/charts/jira/templates/tests/test-shared-home-permissions.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ include "jira.fullname" . }}-shared-home-permissions-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/main/charts/jira/templates/tests/test-shared-home-permissions.yaml
+++ b/src/main/charts/jira/templates/tests/test-shared-home-permissions.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "{{ include "jira.fullname" . }}-shared-home-permissions-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
     {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -213,6 +213,7 @@ metadata:
   name: "unittest-bitbucket-application-status-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     helm.sh/chart: bitbucket-0.1.0
     app.kubernetes.io/name: bitbucket
@@ -245,6 +246,7 @@ metadata:
   name: "unittest-bitbucket-db-connectivity-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     helm.sh/chart: bitbucket-0.1.0
     app.kubernetes.io/name: bitbucket
@@ -303,6 +305,7 @@ metadata:
   name: "unittest-bitbucket-required-values-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     helm.sh/chart: bitbucket-0.1.0
     app.kubernetes.io/name: bitbucket
@@ -343,6 +346,7 @@ metadata:
   name: "unittest-bitbucket-shared-home-permissions-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     helm.sh/chart: bitbucket-0.1.0
     app.kubernetes.io/name: bitbucket
@@ -391,6 +395,7 @@ metadata:
     label1: value1
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     metadata:

--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -271,7 +271,7 @@ metadata:
   name: "unittest-bitbucket-application-status-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     helm.sh/chart: bitbucket-0.1.0
     app.kubernetes.io/name: bitbucket
@@ -304,7 +304,7 @@ metadata:
   name: "unittest-bitbucket-db-connectivity-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     helm.sh/chart: bitbucket-0.1.0
     app.kubernetes.io/name: bitbucket
@@ -363,7 +363,7 @@ metadata:
   name: "unittest-bitbucket-required-values-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     helm.sh/chart: bitbucket-0.1.0
     app.kubernetes.io/name: bitbucket
@@ -404,7 +404,7 @@ metadata:
   name: "unittest-bitbucket-shared-home-permissions-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     helm.sh/chart: bitbucket-0.1.0
     app.kubernetes.io/name: bitbucket
@@ -453,7 +453,7 @@ metadata:
     label1: value1
   annotations:
     "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
   template:
     metadata:

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -314,6 +314,7 @@ metadata:
   name: "unittest-confluence-application-status-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     helm.sh/chart: confluence-0.1.0
     app.kubernetes.io/name: confluence
@@ -345,6 +346,7 @@ metadata:
   name: "unittest-confluence-db-connectivity-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     helm.sh/chart: confluence-0.1.0
     app.kubernetes.io/name: confluence
@@ -399,6 +401,7 @@ metadata:
   name: "unittest-confluence-required-values-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     helm.sh/chart: confluence-0.1.0
     app.kubernetes.io/name: confluence
@@ -437,6 +440,7 @@ metadata:
   name: "unittest-confluence-shared-home-permissions-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     helm.sh/chart: confluence-0.1.0
     app.kubernetes.io/name: confluence
@@ -485,6 +489,7 @@ metadata:
     label1: value1
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     metadata:

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -373,7 +373,7 @@ metadata:
   name: "unittest-confluence-application-status-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     helm.sh/chart: confluence-0.1.0
     app.kubernetes.io/name: confluence
@@ -405,7 +405,7 @@ metadata:
   name: "unittest-confluence-db-connectivity-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     helm.sh/chart: confluence-0.1.0
     app.kubernetes.io/name: confluence
@@ -460,7 +460,7 @@ metadata:
   name: "unittest-confluence-required-values-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     helm.sh/chart: confluence-0.1.0
     app.kubernetes.io/name: confluence
@@ -499,7 +499,7 @@ metadata:
   name: "unittest-confluence-shared-home-permissions-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     helm.sh/chart: confluence-0.1.0
     app.kubernetes.io/name: confluence
@@ -548,7 +548,7 @@ metadata:
     label1: value1
   annotations:
     "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
   template:
     metadata:

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -176,6 +176,7 @@ metadata:
   name: "unittest-jira-application-status-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     helm.sh/chart: jira-0.1.0
     app.kubernetes.io/name: jira
@@ -208,6 +209,7 @@ metadata:
   name: "unittest-jira-db-connectivity-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     helm.sh/chart: jira-0.1.0
     app.kubernetes.io/name: jira
@@ -266,6 +268,7 @@ metadata:
   name: "unittest-jira-required-values-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     helm.sh/chart: jira-0.1.0
     app.kubernetes.io/name: jira
@@ -306,6 +309,7 @@ metadata:
   name: "unittest-jira-shared-home-permissions-test"
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     helm.sh/chart: jira-0.1.0
     app.kubernetes.io/name: jira
@@ -354,6 +358,7 @@ metadata:
     label1: value1
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     metadata:

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -189,7 +189,7 @@ metadata:
   name: "unittest-jira-application-status-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     helm.sh/chart: jira-0.1.0
     app.kubernetes.io/name: jira
@@ -222,7 +222,7 @@ metadata:
   name: "unittest-jira-db-connectivity-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     helm.sh/chart: jira-0.1.0
     app.kubernetes.io/name: jira
@@ -281,7 +281,7 @@ metadata:
   name: "unittest-jira-required-values-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     helm.sh/chart: jira-0.1.0
     app.kubernetes.io/name: jira
@@ -322,7 +322,7 @@ metadata:
   name: "unittest-jira-shared-home-permissions-test"
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     helm.sh/chart: jira-0.1.0
     app.kubernetes.io/name: jira
@@ -371,7 +371,7 @@ metadata:
     label1: value1
   annotations:
     "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 spec:
   template:
     metadata:

--- a/src/test/scripts/helm_install.sh
+++ b/src/test/scripts/helm_install.sh
@@ -81,7 +81,7 @@ then
 fi
 
 # Run the chart's tests
-helm test "$PRODUCT_RELEASE_NAME" --logs -n "${TARGET_NAMESPACE}"
+helm test "$PRODUCT_RELEASE_NAME" -n "${TARGET_NAMESPACE}"
 
 # Package and install the functest helm chart
 INGRESS_DOMAIN_VARIABLE_NAME="INGRESS_DOMAIN_$clusterType"


### PR DESCRIPTION
Adds the following annotation to each Chart hook we have in our charts (i.e. the chart tests, and the nfs-permission-fixers):

    "helm.sh/hook-delete-policy": hook-succeeded

This will ensure that the hook pods are cleaned up when they're finished, rather than cuttering up the namespace as they currently do. Note that Helm hook pods are *not* cleaned up by `helm uninstall`, unlike every other resource in the Chart.

No, I don't know why either.