### PR TITLE
DCNG-927 Make Tomcat https/secure config consistent between products

### DIFF
--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -27,16 +27,17 @@ Kubernetes: `>=1.17.x-0`
 | bitbucket.additionalJvmArgs | string | `nil` | Specifies a list of additional arguments that can be passed to the Bitbucket JVM, e.g. system properties |
 | bitbucket.additionalLibraries | list | `[]` | Specifies a list of additional Java libraries that should be added to the Bitbucket container. Each item in the list should specify the name of the volume which contain the library, as well as the name of the library file within that volume's root directory. Optionally, a subDirectory field can be included to specify which directory in the volume contains the library file. |
 | bitbucket.additionalVolumeMounts | list | `[]` | Defines any additional volumes mounts for the Bitbucket container. These can refer to existing volumes, or new volumes can be defined in volumes.additional. |
+| bitbucket.clustering.enabled | bool | `false` | Set to true if Data Center clustering should be enabled This will automatically configure cluster peer discovery between cluster nodes. |
 | bitbucket.gid | string | `"2003"` | The GID used by the Bitbucket docker image |
+| bitbucket.ingress.fqdn | string | `nil` | The fully-qualified domain name of the ingress |
+| bitbucket.ingress.port | int | `443` | The port number of the ingress |
+| bitbucket.ingress.scheme | string | `"https"` | The protocol scheme used by the browser to access the application. This is necessary so that the application generates the correct URLs. Note that, if present, the value of x-forwarded-proto header will override this setting. |
+| bitbucket.ingress.secure | bool | `true` | Set to true if the connection between the Ingress and the application should be considered secure. |
 | bitbucket.license.secretKey | string | `"license-key"` | The key in the Kubernetes Secret which contains the Bitbucket license key |
-| bitbucket.license.secretName | string | `"bitbucket-license"` | The name of the Kubernetes Secret which contains the Bitbucket license key |
+| bitbucket.license.secretName | string | `nil` | The name of the Kubernetes Secret which contains the Bitbucket license key. If specified, then the license will be automatically populated during Bitbucket setup. Otherwise, it will need to be provided via the browser after initial startup. |
 | bitbucket.ports.hazelcast | int | `5701` |  |
 | bitbucket.ports.http | int | `7990` |  |
 | bitbucket.ports.ssh | int | `7999` |  |
-| bitbucket.proxy.fqdn | string | `nil` | The fully-qualified domain name of the ingress |
-| bitbucket.proxy.port | int | `443` | The port number of the ingress |
-| bitbucket.proxy.scheme | string | `"https"` | note that, if present, the value of x-forwarded-proto header will trump this setting |
-| bitbucket.proxy.secure | bool | `true` |  |
 | bitbucket.resources.container | object | `{}` | Specifies the standard Kubernetes resource requests and/or limits for the Bitbucket container. It is important that if the memory resources are specified here, they must allow for the size of the Bitbucket JVM. That means the maximum heap size, the reserved code cache size, plus other JVM overheads, must be accommodated. Allowing for (maxHeap+codeCache)*1.5 would be an example. |
 | bitbucket.resources.jvm.maxHeap | string | `"1g"` | The maximum amount of heap memory that will be used by the Bitbucket JVM |
 | bitbucket.resources.jvm.minHeap | string | `"1g"` | The minimum amount of heap memory that will be used by the Bitbucket JVM |
@@ -45,13 +46,13 @@ Kubernetes: `>=1.17.x-0`
 | bitbucket.sysadminCredentials.displayNameSecretKey | string | `"displayName"` | The key in the Kubernetes Secret which contains the sysadmin display name |
 | bitbucket.sysadminCredentials.emailAddressSecretKey | string | `"emailAddress"` | The key in the Kubernetes Secret which contains the sysadmin email address |
 | bitbucket.sysadminCredentials.passwordSecretKey | string | `"password"` | The key in the Kubernetes Secret which contains the sysadmin password |
-| bitbucket.sysadminCredentials.secretName | string | `"bitbucket-sysadmin-credentials"` | The name of the Kubernetes Secret which contains the Bitbucket sysadmin credentials |
+| bitbucket.sysadminCredentials.secretName | string | `nil` | The name of the Kubernetes Secret which contains the Bitbucket sysadmin credentials If specified, then these will be automatically populated during Bitbucket setup. Otherwise, they will need to be provided via the browser after initial startup. |
 | bitbucket.sysadminCredentials.usernameSecretKey | string | `"username"` | The key in the Kubernetes Secret which contains the sysadmin username |
 | database.credentials.passwordSecretKey | string | `"password"` | The key in the Secret used to store the database login password |
-| database.credentials.secretName | string | `"bitbucket-database-credentials"` | The name of the Kubernetes Secret that contains the database login credentials. |
+| database.credentials.secretName | string | `nil` | The name of the Kubernetes Secret that contains the database login credentials. If specified, then the credentials will be automatically populated during Bitbucket setup. Otherwise, they will need to be provided via the browser after initial startup. |
 | database.credentials.usernameSecretKey | string | `"username"` | The key in the Secret used to store the database login username |
-| database.driver | string | `nil` | The Java class name of the JDBC driver to be used, e.g. org.postgresql.Driver |
-| database.url | string | `nil` | The JDBC URL of the database to be used by Bitbucket, e.g. jdbc:postgresql://host:port/database |
+| database.driver | string | `nil` | The Java class name of the JDBC driver to be used, e.g. org.postgresql.Driver If not specified, then it will need to be provided via browser during initial startup. |
+| database.url | string | `nil` | The JDBC URL of the database to be used by Bitbucket, e.g. jdbc:postgresql://host:port/database If not specified, then it will need to be provided via browser during initial startup. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"atlassian/bitbucket-server"` |  |
 | image.tag | string | `""` | The docker image tag to be used. Defaults to the Chart appVersion. |
@@ -67,16 +68,19 @@ Kubernetes: `>=1.17.x-0`
 | serviceAccount.name | string | `nil` | Specifies the name of the ServiceAccount to be used by the pods. If not specified, but the the "serviceAccount.create" flag is set, then the ServiceAccount name will be auto-generated, otherwise the 'default' ServiceAccount will be used. |
 | tolerations | list | `[]` | Standard Kubernetes tolerations that will be applied to all Bitbucket pods |
 | volumes.additional | list | `[]` | Defines additional volumes that should be applied to all Bitbucket pods. Note that this will not create any corresponding volume mounts; those needs to be defined in bitbucket.additionalVolumeMounts |
-| volumes.localHome.customVolume | object | `{}` | A standard Kubernetes volume definition that should be used for the local-home volume. If defined, this will declared inline with the pod. If not defined, then an emptyDir will be used. |
+| volumes.localHome.customVolume | string | `nil` | When persistentVolumeClaim.create is false, then this value can be used to define a standard Kubernetes volume which will be used for the local-home volumes. If not defined, then defaults to an emptyDir volume. |
 | volumes.localHome.mountPath | string | `"/var/atlassian/application-data/bitbucket"` |  |
-| volumes.localHome.persistentVolumeClaim.enabled | bool | `false` | Indicates if the local-home volume should be backed by a PersistentVolumeClaim. If false (the default) then a volume will be declared inline within the pods. If true, then a PersistentVolumeClaim will be created for each pod. |
+| volumes.localHome.persistentVolumeClaim.create | bool | `false` | If true, then a PersistentVolumeClaim will be created for each local-home volume. |
 | volumes.localHome.persistentVolumeClaim.resources | object | `{"requests":{"storage":"1Gi"}}` | Specifies the standard Kubernetes resource requests and/or limits for the local-home volume claims. |
 | volumes.localHome.persistentVolumeClaim.storageClassName | string | `nil` | Specifies the name of the storage class that should be used for the local-home volume claim. |
-| volumes.sharedHome.customVolume | object | `{}` | A standard Kubernetes volume definition that should be used for the shared-home volume. If defined, this will declared inline with the pod. If not defined, then an emptyDir will be used. |
+| volumes.sharedHome.customVolume | string | `nil` | When persistentVolumeClaim.create is false, then this value can be used to define a standard Kubernetes volume which will be used for the shared-home volume. If not defined, then defaults to an emptyDir (i.e. unshared) volume. |
 | volumes.sharedHome.mountPath | string | `"/var/atlassian/application-data/shared-home"` | Specifies the path in the Bitbucket container to which the shared-home volume will be mounted. |
 | volumes.sharedHome.nfsPermissionFixer.command | string | `nil` | By default, the fixer will change the group ownership of the volume's root directory to match the Bitbucket container's GID (2003), and then ensures the directory is group-writeable. If this is not the desired behaviour, command used can be specified here. |
 | volumes.sharedHome.nfsPermissionFixer.enabled | bool | `false` | If enabled, this will alter the shared-home volume's root directory so that Bitbucket can write to it. This is a workaround for a Kubernetes bug affecting NFS volumes: https://github.com/kubernetes/examples/issues/260 |
 | volumes.sharedHome.nfsPermissionFixer.mountPath | string | `"/shared-home"` | The path in the initContainer where the shared-home volume will be mounted |
+| volumes.sharedHome.persistentVolumeClaim.create | bool | `false` | If true, then a PersistentVolumeClaim will be created for the shared-home volume. |
+| volumes.sharedHome.persistentVolumeClaim.resources | object | `{"requests":{"storage":"1Gi"}}` | Specifies the standard Kubernetes resource requests and/or limits for the shared-home volume claims. |
+| volumes.sharedHome.persistentVolumeClaim.storageClassName | string | `nil` | Specifies the name of the storage class that should be used for the shared-home volume claim. |
 | volumes.sharedHome.subPath | string | `nil` | Specifies the sub-directory of the shared-home volume which will be mounted in to the Bitbucket container. |
 
 ----------------------------------------------

--- a/src/main/charts/bitbucket/templates/_helpers.tpl
+++ b/src/main/charts/bitbucket/templates/_helpers.tpl
@@ -102,10 +102,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{- define "bitbucket.baseUrl" -}}
-{{ $httpPortMismatch := (and (eq .Values.bitbucket.proxy.scheme "http") (ne (int .Values.bitbucket.proxy.port) 80) ) -}}
-{{ $httpsPortMismatch := (and (eq .Values.bitbucket.proxy.scheme "https") (ne (int .Values.bitbucket.proxy.port) 443) ) -}}
-{{ .Values.bitbucket.proxy.scheme }}://{{ .Values.bitbucket.proxy.fqdn -}}
-{{ if or $httpPortMismatch $httpsPortMismatch }}:{{ .Values.bitbucket.proxy.port }}{{ end }}
+{{ $httpPortMismatch := (and (eq .Values.bitbucket.ingress.scheme "http") (ne (int .Values.bitbucket.ingress.port) 80) ) -}}
+{{ $httpsPortMismatch := (and (eq .Values.bitbucket.ingress.scheme "https") (ne (int .Values.bitbucket.ingress.port) 443) ) -}}
+{{ .Values.bitbucket.ingress.scheme }}://{{ .Values.bitbucket.ingress.fqdn -}}
+{{ if or $httpPortMismatch $httpsPortMismatch }}:{{ .Values.bitbucket.ingress.port }}{{ end }}
 {{- end }}
 
 {{/*

--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -72,18 +72,18 @@ spec:
             {{- include "bitbucket.clusteringEnvVars" . | nindent 12 }}
             {{- include "bitbucket.databaseEnvVars" . | nindent 12 }}
             {{- include "bitbucket.sysadminEnvVars" . | nindent 12 }}
-            {{ if .Values.bitbucket.proxy.fqdn }}
+            {{ if .Values.bitbucket.ingress.fqdn }}
             - name: SERVER_PROXY_NAME
-              value: {{ .Values.bitbucket.proxy.fqdn | quote }}
+              value: {{ .Values.bitbucket.ingress.fqdn | quote }}
             - name: SETUP_BASEURL
               value: {{ include "bitbucket.baseUrl" . | quote }}
             {{ end }}
             - name: SERVER_PROXY_PORT
-              value: {{ .Values.bitbucket.proxy.port | quote }}
+              value: {{ .Values.bitbucket.ingress.port | quote }}
             - name: SERVER_SCHEME
-              value: {{ .Values.bitbucket.proxy.scheme | quote }}
+              value: {{ .Values.bitbucket.ingress.scheme | quote }}
             - name: SERVER_SECURE
-              value: {{ .Values.bitbucket.proxy.secure | quote }}
+              value: {{ .Values.bitbucket.ingress.secure | quote }}
             - name: BITBUCKET_SHARED_HOME
               value: {{ .Values.volumes.sharedHome.mountPath | quote }}
             {{ with .Values.bitbucket.license.secretName }}

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -86,7 +86,7 @@ bitbucket:
     fqdn:
     # -- The port number of the ingress
     port: 443
-    # -- The protocol scheme used by the ingress that sends traffic to the application.
+    # -- The protocol scheme used by the browser to access the application.
     # This is necessary so that the application generates the correct URLs.
     # Note that, if present, the value of x-forwarded-proto header will override this setting.
     scheme: https

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -81,13 +81,16 @@ bitbucket:
     # -- The key in the Kubernetes Secret which contains the sysadmin email address
     emailAddressSecretKey: emailAddress
 
-  proxy:
+  ingress:
     # -- The fully-qualified domain name of the ingress
     fqdn:
     # -- The port number of the ingress
     port: 443
-    # -- note that, if present, the value of x-forwarded-proto header will trump this setting
+    # -- The protocol scheme used by the ingress that sends traffic to the application.
+    # This is necessary so that the application generates the correct URLs.
+    # Note that, if present, the value of x-forwarded-proto header will override this setting.
     scheme: https
+    # -- Set to true if the connection between the Ingress and the application should be considered secure.
     secure: true
 
   clustering:

--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -66,9 +66,9 @@ spec:
             {{- include "confluence.additionalBundledPlugins" . | nindent 12 }}
           env:
             - name: ATL_TOMCAT_SCHEME
-              value: https
+              value: {{ .Values.confluence.ingress.scheme | quote }}
             - name: ATL_TOMCAT_SECURE
-              value: "true"
+              value: {{ .Values.confluence.ingress.secure | quote }}
             - name: ATL_PRODUCT_HOME_SHARED
               value: {{ .Values.volumes.sharedHome.mountPath | quote }}
             - name: JVM_SUPPORT_RECOMMENDED_ARGS

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -62,6 +62,12 @@ confluence:
     http: 8090
     # -- The port on which the Confluence container listens for Hazelcast traffic
     hazelcast: 5701
+  ingress:
+    # -- The protocol scheme used by the ingress that sends traffic to the application.
+    # This is necessary so that the application generates the correct URLs.
+    scheme: https
+    # -- Set to true if the connection between the Ingress and the application should be considered secure.
+    secure: true
   license:
     # -- The name of the Kubernetes Secret which contains the Confluence license key.
     # If specified, then the license will be automatically populated during Confluence setup.

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -63,7 +63,7 @@ confluence:
     # -- The port on which the Confluence container listens for Hazelcast traffic
     hazelcast: 5701
   ingress:
-    # -- The protocol scheme used by the ingress that sends traffic to the application.
+    # -- The protocol scheme used by the browser to access the application.
     # This is necessary so that the application generates the correct URLs.
     scheme: https
     # -- Set to true if the connection between the Ingress and the application should be considered secure.

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -23,11 +23,11 @@ Kubernetes: `>=1.17.x-0`
 | additionalLabels | object | `{}` | Additional labels that should be applied to all resources |
 | affinity | object | `{}` | Standard Kubernetes affinities that will be applied to all Jira pods |
 | database.credentials.passwordSecretKey | string | `"password"` | The key in the Secret used to store the database login password |
-| database.credentials.secretName | string | `"jira-database-credentials"` | The name of the Kubernetes Secret that contains the database login credentials. |
+| database.credentials.secretName | string | `nil` | The name of the Kubernetes Secret that contains the database login credentials. If specified, then the credentials will be automatically populated during Jira setup. Otherwise, they will need to be provided via the browser after initial startup. |
 | database.credentials.usernameSecretKey | string | `"username"` | The key in the Secret used to store the database login username |
-| database.driver | string | `nil` | The Java class name of the JDBC driver to be used, e.g. org.postgresql.Driver |
-| database.type | string | `nil` | The type of database being used. Valid values include 'postgres72', 'mysql57', 'mysql8', 'oracle10g', 'mssql', 'postgresaurora96' |
-| database.url | string | `nil` | The JDBC URL of the database to be used by Jira, e.g. jdbc:postgresql://host:port/database |
+| database.driver | string | `nil` | The Java class name of the JDBC driver to be used, e.g. org.postgresql.Driver If not specified, then it will need to be provided via browser during initial startup. |
+| database.type | string | `nil` | The type of database being used. Valid values include 'postgres72', 'mysql57', 'mysql8', 'oracle10g', 'mssql', 'postgresaurora96' If not specified, then it will need to be provided via browser during initial startup. |
+| database.url | string | `nil` | The JDBC URL of the database to be used by Jira, e.g. jdbc:postgresql://host:port/database If not specified, then it will need to be provided via browser during initial startup. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"atlassian/jira-software"` |  |
 | image.tag | string | `""` | The docker image tag to be used. Defaults to the Chart appVersion. |
@@ -36,7 +36,10 @@ Kubernetes: `>=1.17.x-0`
 | jira.additionalJvmArgs | string | `nil` | Specifies a list of additional arguments that can be passed to the Jira JVM, e.g. system properties |
 | jira.additionalLibraries | list | `[]` | Specifies a list of additional Java libraries that should be added to the Jira container. Each item in the list should specify the name of the volume which contain the library, as well as the name of the library file within that volume's root directory. Optionally, a subDirectory field can be included to specify which directory in the volume contains the library file. |
 | jira.additionalVolumeMounts | list | `[]` | Defines any additional volumes mounts for the Jira container. These can refer to existing volumes, or new volumes can be defined in volumes.additional. |
+| jira.clustering.enabled | bool | `false` | Set to true if Data Center clustering should be enabled This will automatically configure cluster peer discovery between cluster nodes. |
 | jira.gid | string | `"2001"` | The GID used by the Jira docker image |
+| jira.ingress.scheme | string | `"https"` | The protocol scheme used by the browser to access the application. This is necessary so that the application generates the correct URLs. |
+| jira.ingress.secure | bool | `true` | Set to true if the connection between the Ingress and the application should be considered secure. |
 | jira.ports.http | int | `8080` | The port on which the Jira container listens for HTTP traffic |
 | jira.readinessProbe.failureThreshold | int | `30` | The number of consecutive failures of the Jira container readiness probe before the pod fails readiness checks |
 | jira.readinessProbe.initialDelaySeconds | int | `10` | The initial delay (in seconds) for the Jira container readiness probe, after which the probe will start running |
@@ -55,16 +58,19 @@ Kubernetes: `>=1.17.x-0`
 | serviceAccount.name | string | `nil` | Specifies the name of the ServiceAccount to be used by the pods. If not specified, but the the "serviceAccount.create" flag is set, then the ServiceAccount name will be auto-generated, otherwise the 'default' ServiceAccount will be used. |
 | tolerations | list | `[]` | Standard Kubernetes tolerations that will be applied to all Jira pods |
 | volumes.additional | list | `[]` | Defines additional volumes that should be applied to all Jira pods. Note that this will not create any corresponding volume mounts; those needs to be defined in jira.additionalVolumeMounts |
-| volumes.localHome.customVolume | object | `{}` | A standard Kubernetes volume definition that should be used for the local-home volume. If defined, this will declared inline with the pod. If not defined, then an emptyDir will be used. |
+| volumes.localHome.customVolume | string | `nil` | When persistentVolumeClaim.create is false, then this value can be used to define a standard Kubernetes volume which will be used for the local-home volumes. If not defined, then defaults to an emptyDir volume. |
 | volumes.localHome.mountPath | string | `"/var/atlassian/application-data/jira"` | Specifies the path in the Jira container to which the local-home volume will be mounted. |
-| volumes.localHome.persistentVolumeClaim.enabled | bool | `false` | Indicates if the local-home volume should be backed by a PersistentVolumeClaim. If false (the default) then a volume will be declared inline within the pods. If true, then a PersistentVolumeClaim will be created for each pod. |
+| volumes.localHome.persistentVolumeClaim.create | bool | `false` | If true, then a PersistentVolumeClaim will be created for each local-home volume. |
 | volumes.localHome.persistentVolumeClaim.resources | object | `{"requests":{"storage":"1Gi"}}` | Specifies the standard Kubernetes resource requests and/or limits for the local-home volume claims. |
 | volumes.localHome.persistentVolumeClaim.storageClassName | string | `nil` | Specifies the name of the storage class that should be used for the local-home volume claim. |
-| volumes.sharedHome.customVolume | object | `{}` | A standard Kubernetes volume definition that should be used for the shared-home volume. If defined, this will declared inline with the pod. If not defined, then an emptyDir will be used. |
+| volumes.sharedHome.customVolume | string | `nil` | When persistentVolumeClaim.create is false, then this value can be used to define a standard Kubernetes volume which will be used for the shared-home volume. If not defined, then defaults to an emptyDir (i.e. unshared) volume. |
 | volumes.sharedHome.mountPath | string | `"/var/atlassian/application-data/shared-home"` | Specifies the path in the Jira container to which the shared-home volume will be mounted. |
 | volumes.sharedHome.nfsPermissionFixer.command | string | `nil` | By default, the fixer will change the group ownership of the volume's root directory to match the Jira container's GID (2001), and then ensures the directory is group-writeable. If this is not the desired behaviour, command used can be specified here. |
 | volumes.sharedHome.nfsPermissionFixer.enabled | bool | `false` | If enabled, this will alter the shared-home volume's root directory so that Jira can write to it. This is a workaround for a Kubernetes bug affecting NFS volumes: https://github.com/kubernetes/examples/issues/260 |
 | volumes.sharedHome.nfsPermissionFixer.mountPath | string | `"/shared-home"` | The path in the initContainer where the shared-home volume will be mounted |
+| volumes.sharedHome.persistentVolumeClaim.create | bool | `false` | If true, then a PersistentVolumeClaim will be created for the shared-home volume. |
+| volumes.sharedHome.persistentVolumeClaim.resources | object | `{"requests":{"storage":"1Gi"}}` | Specifies the standard Kubernetes resource requests and/or limits for the shared-home volume claims. |
+| volumes.sharedHome.persistentVolumeClaim.storageClassName | string | `nil` | Specifies the name of the storage class that should be used for the shared-home volume claim. |
 | volumes.sharedHome.subPath | string | `nil` | Specifies the sub-directory of the shared-home volume which will be mounted in to the Jira container. |
 
 ----------------------------------------------

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -35,9 +35,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: ATL_TOMCAT_SCHEME
-              value: https
+              value: {{ .Values.jira.ingress.scheme | quote }}
             - name: ATL_TOMCAT_SECURE
-              value: "true"
+              value: {{ .Values.jira.ingress.secure | quote }}
             {{- include "jira.databaseEnvVars" . | nindent 12 }}
             {{- include "jira.clusteringEnvVars" . | nindent 12 }}
             - name: JIRA_SHARED_HOME

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -53,7 +53,7 @@ jira:
     # -- The port on which the Jira container listens for HTTP traffic
     http: 8080
   ingress:
-    # -- The protocol scheme used by the ingress that sends traffic to the application.
+    # -- The protocol scheme used by the browser to access the application.
     # This is necessary so that the application generates the correct URLs.
     scheme: https
     # -- Set to true if the connection between the Ingress and the application should be considered secure.

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -52,6 +52,12 @@ jira:
   ports:
     # -- The port on which the Jira container listens for HTTP traffic
     http: 8080
+  ingress:
+    # -- The protocol scheme used by the ingress that sends traffic to the application.
+    # This is necessary so that the application generates the correct URLs.
+    scheme: https
+    # -- Set to true if the connection between the Ingress and the application should be considered secure.
+    secure: true
   readinessProbe:
     # -- The initial delay (in seconds) for the Jira container readiness probe, after which the probe will start running
     initialDelaySeconds: 10

--- a/src/test/config/bitbucket/values-EKS.yaml
+++ b/src/test/config/bitbucket/values-EKS.yaml
@@ -4,7 +4,7 @@ serviceAccount:
     - name: regcred
 
 bitbucket:
-  proxy:
+  ingress:
     fqdn: ${helm.release.prefix}-bitbucket.${eks.ingress.domain}
 
 volumes:

--- a/src/test/config/bitbucket/values-KITT.yaml
+++ b/src/test/config/bitbucket/values-KITT.yaml
@@ -12,7 +12,7 @@ podAnnotations:
   "atlassian.com/business_unit": "server_engineering"
 
 bitbucket:
-  proxy:
+  ingress:
     fqdn: ${helm.release.prefix}-bitbucket.${kitt.ingress.domain}
 
 volumes:

--- a/src/test/java/test/IngressTest.java
+++ b/src/test/java/test/IngressTest.java
@@ -1,0 +1,49 @@
+package test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import test.helm.Helm;
+import test.model.Product;
+
+import java.util.Map;
+
+import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
+
+class IngressTest {
+    private Helm helm;
+
+    @BeforeEach
+    void initHelm(TestInfo testInfo) {
+        helm = new Helm(testInfo);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, mode = EXCLUDE, names = "bitbucket")
+    void https_disabled(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                product + ".ingress.secure", "false",
+                product + ".ingress.scheme", "http"));
+
+        resources.getStatefulSet(product.getHelmReleaseName())
+                .getContainer()
+                .getEnv()
+                .assertHasValue("ATL_TOMCAT_SCHEME", "http")
+                .assertHasValue("ATL_TOMCAT_SECURE", "false");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = "bitbucket")
+    void https_disabled_bitbucket(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                product + ".ingress.secure", "false",
+                product + ".ingress.scheme", "http"));
+
+        resources.getStatefulSet(product.getHelmReleaseName())
+                .getContainer()
+                .getEnv()
+                .assertHasValue("SERVER_SCHEME", "http")
+                .assertHasValue("SERVER_SECURE", "false");
+    }
+}

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -112,7 +112,7 @@ spec:
               mountPath: "/var/atlassian/application-data/shared-home"
           env:
             - name: ATL_TOMCAT_SCHEME
-              value: https
+              value: "https"
             - name: ATL_TOMCAT_SECURE
               value: "true"
             - name: ATL_PRODUCT_HOME_SHARED

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -86,7 +86,7 @@ spec:
           imagePullPolicy: IfNotPresent
           env:
             - name: ATL_TOMCAT_SCHEME
-              value: https
+              value: "https"
             - name: ATL_TOMCAT_SECURE
               value: "true"
             - name: JIRA_SHARED_HOME


### PR DESCRIPTION
The Bitbucket Helm chart allows the Tomcat "scheme" and "secure" config properties to be configured via chart vaues, but the other products' charts do not.

This PR makes them consistent by using the same value structure for all 3. In the process I've renamed the `bitbucket.proxy` structure to `bitbucket.ingress` (and also for confluence+jira), since the ingress is the kubernetes terminoogy for what the Bitbucket docs call a "proxy".