### PR TITLE
DCNG-906 Add support for declaring ElasticSearch properties

### DIFF
--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -28,7 +28,7 @@ Kubernetes: `>=1.17.x-0`
 | bitbucket.additionalLibraries | list | `[]` | Specifies a list of additional Java libraries that should be added to the Bitbucket container. Each item in the list should specify the name of the volume which contain the library, as well as the name of the library file within that volume's root directory. Optionally, a subDirectory field can be included to specify which directory in the volume contains the library file. |
 | bitbucket.additionalVolumeMounts | list | `[]` | Defines any additional volumes mounts for the Bitbucket container. These can refer to existing volumes, or new volumes can be defined in volumes.additional. |
 | bitbucket.clustering.enabled | bool | `false` | Set to true if Data Center clustering should be enabled This will automatically configure cluster peer discovery between cluster nodes. |
-| bitbucket.elasticSearch.baseUrl | string | `nil` | The base URL of the ElasticSearch instance to be used. |
+| bitbucket.elasticSearch.baseUrl | string | `nil` | The base URL of the external ElasticSearch instance to be used. If this is defined, then Bitbucket will disable its internal ElasticSearch instance. |
 | bitbucket.elasticSearch.credentials.passwordSecretKey | string | `"password"` | The key in the the Kubernetes Secret that contains the ElasticSearch password. |
 | bitbucket.elasticSearch.credentials.secretName | string | `nil` | The name of the Kubernetes Secret that contains the ElasticSearch credentials. |
 | bitbucket.elasticSearch.credentials.usernameSecreyKey | string | `"username"` | The key in the the Kubernetes Secret that contains the ElasticSearch username. |

--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -28,6 +28,10 @@ Kubernetes: `>=1.17.x-0`
 | bitbucket.additionalLibraries | list | `[]` | Specifies a list of additional Java libraries that should be added to the Bitbucket container. Each item in the list should specify the name of the volume which contain the library, as well as the name of the library file within that volume's root directory. Optionally, a subDirectory field can be included to specify which directory in the volume contains the library file. |
 | bitbucket.additionalVolumeMounts | list | `[]` | Defines any additional volumes mounts for the Bitbucket container. These can refer to existing volumes, or new volumes can be defined in volumes.additional. |
 | bitbucket.clustering.enabled | bool | `false` | Set to true if Data Center clustering should be enabled This will automatically configure cluster peer discovery between cluster nodes. |
+| bitbucket.elasticSearch.baseUrl | string | `nil` | The base URL of the ElasticSearch instance to be used. |
+| bitbucket.elasticSearch.credentials.passwordSecretKey | string | `"password"` | The key in the the Kubernetes Secret that contains the ElasticSearch password. |
+| bitbucket.elasticSearch.credentials.secretName | string | `nil` | The name of the Kubernetes Secret that contains the ElasticSearch credentials. |
+| bitbucket.elasticSearch.credentials.usernameSecreyKey | string | `"username"` | The key in the the Kubernetes Secret that contains the ElasticSearch username. |
 | bitbucket.gid | string | `"2003"` | The GID used by the Bitbucket docker image |
 | bitbucket.ingress.fqdn | string | `nil` | The fully-qualified domain name of the ingress |
 | bitbucket.ingress.port | int | `443` | The port number of the ingress |

--- a/src/main/charts/bitbucket/templates/_helpers.tpl
+++ b/src/main/charts/bitbucket/templates/_helpers.tpl
@@ -273,3 +273,22 @@ volumeClaimTemplates:
   value: {{ .Values.bitbucket.ports.hazelcast | quote }}
 {{ end }}
 {{ end }}
+
+{{- define "bitbucket.elasticSearchEnvVars" -}}
+{{ with .Values.bitbucket.elasticSearch.baseUrl }}
+- name: PLUGIN_SEARCH_ELASTICSEARCH_BASEURL
+  value: {{ . | quote }}
+{{ end }}
+{{ if .Values.bitbucket.elasticSearch.credentials.secretName }}
+- name: PLUGIN_SEARCH_ELASTICSEARCH_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.bitbucket.elasticSearch.credentials.secretName | quote }}
+      key: {{ .Values.bitbucket.elasticSearch.credentials.usernameSecreyKey | quote }}
+- name: PLUGIN_SEARCH_ELASTICSEARCH_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.bitbucket.elasticSearch.credentials.secretName | quote }}
+      key: {{ .Values.bitbucket.elasticSearch.credentials.passwordSecretKey | quote }}
+{{ end }}
+{{ end }}

--- a/src/main/charts/bitbucket/templates/_helpers.tpl
+++ b/src/main/charts/bitbucket/templates/_helpers.tpl
@@ -276,6 +276,8 @@ volumeClaimTemplates:
 
 {{- define "bitbucket.elasticSearchEnvVars" -}}
 {{ with .Values.bitbucket.elasticSearch.baseUrl }}
+- name: ELASTICSEARCH_ENABLED
+  value: "false"
 - name: PLUGIN_SEARCH_ELASTICSEARCH_BASEURL
   value: {{ . | quote }}
 {{ end }}

--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -72,6 +72,7 @@ spec:
             {{- include "bitbucket.clusteringEnvVars" . | nindent 12 }}
             {{- include "bitbucket.databaseEnvVars" . | nindent 12 }}
             {{- include "bitbucket.sysadminEnvVars" . | nindent 12 }}
+            {{- include "bitbucket.elasticSearchEnvVars" . | nindent 12 }}
             {{ if .Values.bitbucket.ingress.fqdn }}
             - name: SERVER_PROXY_NAME
               value: {{ .Values.bitbucket.ingress.fqdn | quote }}

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -98,6 +98,17 @@ bitbucket:
     # This will automatically configure cluster peer discovery between cluster nodes.
     enabled: false
 
+  elasticSearch:
+    # -- The base URL of the ElasticSearch instance to be used.
+    baseUrl:
+    credentials:
+      # -- The name of the Kubernetes Secret that contains the ElasticSearch credentials.
+      secretName:
+      # -- The key in the the Kubernetes Secret that contains the ElasticSearch username.
+      usernameSecreyKey: username
+      # -- The key in the the Kubernetes Secret that contains the ElasticSearch password.
+      passwordSecretKey: password
+
   resources:
     jvm:
       # -- The maximum amount of heap memory that will be used by the Bitbucket JVM

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -99,7 +99,8 @@ bitbucket:
     enabled: false
 
   elasticSearch:
-    # -- The base URL of the ElasticSearch instance to be used.
+    # -- The base URL of the external ElasticSearch instance to be used.
+    # If this is defined, then Bitbucket will disable its internal ElasticSearch instance.
     baseUrl:
     credentials:
       # -- The name of the Kubernetes Secret that contains the ElasticSearch credentials.

--- a/src/test/java/test/ElasticSearchTest.java
+++ b/src/test/java/test/ElasticSearchTest.java
@@ -1,0 +1,44 @@
+package test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import test.helm.Helm;
+import test.model.Product;
+
+import java.util.Map;
+
+class ElasticSearchTest {
+    private Helm helm;
+
+    @BeforeEach
+    void initHelm(TestInfo testInfo) {
+        helm = new Helm(testInfo);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = "bitbucket")
+    void elastic_search_baseUrl(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                product + ".elasticSearch.baseUrl", "https://foo/"));
+
+        resources.getStatefulSet(product.getHelmReleaseName())
+                .getContainer()
+                .getEnv()
+                .assertHasValue("PLUGIN_SEARCH_ELASTICSEARCH_BASEURL", "https://foo/");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = "bitbucket")
+    void elastic_search_credentials(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                product + ".elasticSearch.credentials.secretName", "mysecret"));
+
+        resources.getStatefulSet(product.getHelmReleaseName())
+                .getContainer()
+                .getEnv()
+                .assertHasSecretRef("PLUGIN_SEARCH_ELASTICSEARCH_USERNAME", "mysecret", "username")
+                .assertHasSecretRef("PLUGIN_SEARCH_ELASTICSEARCH_PASSWORD", "mysecret", "password");
+    }
+}

--- a/src/test/java/test/ElasticSearchTest.java
+++ b/src/test/java/test/ElasticSearchTest.java
@@ -26,6 +26,7 @@ class ElasticSearchTest {
         resources.getStatefulSet(product.getHelmReleaseName())
                 .getContainer()
                 .getEnv()
+                .assertHasValue("ELASTICSEARCH_ENABLED", "false")
                 .assertHasValue("PLUGIN_SEARCH_ELASTICSEARCH_BASEURL", "https://foo/");
     }
 


### PR DESCRIPTION
Adds a new optional structure to the Bitbucket chart values, allowing for the declaration of the ElasticSearch base URL and credentials.

It's pretty basic at this point, but means the customer won't have to manually specify the additional environment varables themselves.

It mandates that the credentials are stored in a Kubernetes secret, consistent with the other optional credentials in the charts.