### PR TITLE
DCNG-892 Add Ingress templates

### DIFF
--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -59,6 +59,7 @@ Kubernetes: `>=1.17.x-0`
 | ingress.annotations | object | `{}` | The custom annotations that should be applied to the Ingress. |
 | ingress.create | bool | `false` | True if an Ingress should be created. |
 | ingress.host | string | `nil` | The fully-qualified hostname of the Ingress. |
+| ingress.nginx | bool | `true` | True if the created Ingress is to use the Kubernetes ingress-nginx controller. This will populate the Ingress with annotations for that controller. Set to false if a different controller is to be used, in which case the annotations need to be specified. |
 | ingress.port | int | `443` | The port number of the ingress |
 | ingress.scheme | string | `"https"` | The protocol scheme used by the browser to access the application. This is necessary so that the application generates the correct URLs. Note that, if present, the value of x-forwarded-proto header will override this setting. |
 | ingress.secure | bool | `true` | Set to true if the connection between the Ingress and the application should be considered secure. |

--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -29,10 +29,6 @@ Kubernetes: `>=1.17.x-0`
 | bitbucket.additionalVolumeMounts | list | `[]` | Defines any additional volumes mounts for the Bitbucket container. These can refer to existing volumes, or new volumes can be defined in volumes.additional. |
 | bitbucket.clustering.enabled | bool | `false` | Set to true if Data Center clustering should be enabled This will automatically configure cluster peer discovery between cluster nodes. |
 | bitbucket.gid | string | `"2003"` | The GID used by the Bitbucket docker image |
-| bitbucket.ingress.fqdn | string | `nil` | The fully-qualified domain name of the ingress |
-| bitbucket.ingress.port | int | `443` | The port number of the ingress |
-| bitbucket.ingress.scheme | string | `"https"` | The protocol scheme used by the browser to access the application. This is necessary so that the application generates the correct URLs. Note that, if present, the value of x-forwarded-proto header will override this setting. |
-| bitbucket.ingress.secure | bool | `true` | Set to true if the connection between the Ingress and the application should be considered secure. |
 | bitbucket.license.secretKey | string | `"license-key"` | The key in the Kubernetes Secret which contains the Bitbucket license key |
 | bitbucket.license.secretName | string | `nil` | The name of the Kubernetes Secret which contains the Bitbucket license key. If specified, then the license will be automatically populated during Bitbucket setup. Otherwise, it will need to be provided via the browser after initial startup. |
 | bitbucket.ports.hazelcast | int | `5701` |  |
@@ -56,6 +52,12 @@ Kubernetes: `>=1.17.x-0`
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"atlassian/bitbucket-server"` |  |
 | image.tag | string | `""` | The docker image tag to be used. Defaults to the Chart appVersion. |
+| ingress.annotations | object | `{}` | The custom annotations that should be applied to the Ingress. |
+| ingress.create | bool | `false` | True if an Ingress should be created. |
+| ingress.host | string | `nil` | The fully-qualified hostname of the Ingress. |
+| ingress.port | int | `443` | The port number of the ingress |
+| ingress.scheme | string | `"https"` | The protocol scheme used by the browser to access the application. This is necessary so that the application generates the correct URLs. Note that, if present, the value of x-forwarded-proto header will override this setting. |
+| ingress.secure | bool | `true` | Set to true if the connection between the Ingress and the application should be considered secure. |
 | nodeSelector | object | `{}` | Standard Kubernetes node-selectors that will be applied to all Bitbucket pods |
 | podAnnotations | object | `{}` | Specify custom annotations to be added to all Bitbucket pods |
 | replicaCount | int | `1` | The initial number of pods that should be started at deployment of Bitbucket. |

--- a/src/main/charts/bitbucket/templates/_helpers.tpl
+++ b/src/main/charts/bitbucket/templates/_helpers.tpl
@@ -102,10 +102,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{- define "bitbucket.baseUrl" -}}
-{{ $httpPortMismatch := (and (eq .Values.bitbucket.ingress.scheme "http") (ne (int .Values.bitbucket.ingress.port) 80) ) -}}
-{{ $httpsPortMismatch := (and (eq .Values.bitbucket.ingress.scheme "https") (ne (int .Values.bitbucket.ingress.port) 443) ) -}}
-{{ .Values.bitbucket.ingress.scheme }}://{{ .Values.bitbucket.ingress.host -}}
-{{ if or $httpPortMismatch $httpsPortMismatch }}:{{ .Values.bitbucket.ingress.port }}{{ end }}
+{{ $httpPortMismatch := (and (eq .Values.ingress.scheme "http") (ne (int .Values.ingress.port) 80) ) -}}
+{{ $httpsPortMismatch := (and (eq .Values.ingress.scheme "https") (ne (int .Values.ingress.port) 443) ) -}}
+{{ .Values.ingress.scheme }}://{{ .Values.ingress.host -}}
+{{ if or $httpPortMismatch $httpsPortMismatch }}:{{ .Values.ingress.port }}{{ end }}
 {{- end }}
 
 {{/*

--- a/src/main/charts/bitbucket/templates/_helpers.tpl
+++ b/src/main/charts/bitbucket/templates/_helpers.tpl
@@ -104,7 +104,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "bitbucket.baseUrl" -}}
 {{ $httpPortMismatch := (and (eq .Values.bitbucket.ingress.scheme "http") (ne (int .Values.bitbucket.ingress.port) 80) ) -}}
 {{ $httpsPortMismatch := (and (eq .Values.bitbucket.ingress.scheme "https") (ne (int .Values.bitbucket.ingress.port) 443) ) -}}
-{{ .Values.bitbucket.ingress.scheme }}://{{ .Values.bitbucket.ingress.fqdn -}}
+{{ .Values.bitbucket.ingress.scheme }}://{{ .Values.bitbucket.ingress.host -}}
 {{ if or $httpPortMismatch $httpsPortMismatch }}:{{ .Values.bitbucket.ingress.port }}{{ end }}
 {{- end }}
 

--- a/src/main/charts/bitbucket/templates/ingress.yaml
+++ b/src/main/charts/bitbucket/templates/ingress.yaml
@@ -5,8 +5,16 @@ metadata:
   name: {{ include "bitbucket.fullname" . }}
   labels:
     {{- include "bitbucket.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
+  {{ if .Values.ingress.nginx }}
+    "kubernetes.io/ingress.class": "nginx"
+    "nginx.ingress.kubernetes.io/affinity": "cookie"
+    "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
+    "nginx.ingress.kubernetes.io/proxy-connect-timeout": "60"
+    "nginx.ingress.kubernetes.io/proxy-read-timeout": "60"
+    "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
+  {{- end }}
+  {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/src/main/charts/bitbucket/templates/ingress.yaml
+++ b/src/main/charts/bitbucket/templates/ingress.yaml
@@ -1,17 +1,17 @@
-{{- if .Values.bitbucket.ingress.create }}
+{{- if .Values.ingress.create }}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "bitbucket.fullname" . }}
   labels:
     {{- include "bitbucket.labels" . | nindent 4 }}
-  {{- with .Values.bitbucket.ingress.annotations }}
+  {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   rules:
-    - host: {{ .Values.bitbucket.ingress.host }}
+    - host: {{ .Values.ingress.host }}
       http:
         paths:
           - path: "/"

--- a/src/main/charts/bitbucket/templates/ingress.yaml
+++ b/src/main/charts/bitbucket/templates/ingress.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.bitbucket.ingress.create }}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "bitbucket.fullname" . }}
+  labels:
+    {{- include "bitbucket.labels" . | nindent 4 }}
+  {{- with .Values.bitbucket.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  rules:
+    - host: {{ .Values.bitbucket.ingress.host }}
+      http:
+        paths:
+          - path: "/"
+            backend:
+              serviceName: {{ include "bitbucket.fullname" $ }}
+              servicePort: {{ $.Values.bitbucket.service.port }}
+{{ end }}

--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -72,18 +72,18 @@ spec:
             {{- include "bitbucket.clusteringEnvVars" . | nindent 12 }}
             {{- include "bitbucket.databaseEnvVars" . | nindent 12 }}
             {{- include "bitbucket.sysadminEnvVars" . | nindent 12 }}
-            {{ if .Values.bitbucket.ingress.host }}
+            {{ if .Values.ingress.host }}
             - name: SERVER_PROXY_NAME
-              value: {{ .Values.bitbucket.ingress.host | quote }}
+              value: {{ .Values.ingress.host | quote }}
             - name: SETUP_BASEURL
               value: {{ include "bitbucket.baseUrl" . | quote }}
             {{ end }}
             - name: SERVER_PROXY_PORT
-              value: {{ .Values.bitbucket.ingress.port | quote }}
+              value: {{ .Values.ingress.port | quote }}
             - name: SERVER_SCHEME
-              value: {{ .Values.bitbucket.ingress.scheme | quote }}
+              value: {{ .Values.ingress.scheme | quote }}
             - name: SERVER_SECURE
-              value: {{ .Values.bitbucket.ingress.secure | quote }}
+              value: {{ .Values.ingress.secure | quote }}
             - name: BITBUCKET_SHARED_HOME
               value: {{ .Values.volumes.sharedHome.mountPath | quote }}
             {{ with .Values.bitbucket.license.secretName }}

--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -72,9 +72,9 @@ spec:
             {{- include "bitbucket.clusteringEnvVars" . | nindent 12 }}
             {{- include "bitbucket.databaseEnvVars" . | nindent 12 }}
             {{- include "bitbucket.sysadminEnvVars" . | nindent 12 }}
-            {{ if .Values.bitbucket.ingress.fqdn }}
+            {{ if .Values.bitbucket.ingress.host }}
             - name: SERVER_PROXY_NAME
-              value: {{ .Values.bitbucket.ingress.fqdn | quote }}
+              value: {{ .Values.bitbucket.ingress.host | quote }}
             - name: SETUP_BASEURL
               value: {{ include "bitbucket.baseUrl" . | quote }}
             {{ end }}

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -138,6 +138,10 @@ bitbucket:
 ingress:
   # -- True if an Ingress should be created.
   create: false
+  # -- True if the created Ingress is to use the Kubernetes ingress-nginx controller.
+  # This will populate the Ingress with annotations for that controller.
+  # Set to false if a different controller is to be used, in which case the annotations need to be specified.
+  nginx: true
   # -- The fully-qualified hostname of the Ingress.
   host:
   # -- The custom annotations that should be applied to the Ingress.

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -81,22 +81,6 @@ bitbucket:
     # -- The key in the Kubernetes Secret which contains the sysadmin email address
     emailAddressSecretKey: emailAddress
 
-  ingress:
-    # -- True if an Ingress should be created.
-    create: false
-    # -- The fully-qualified hostname of the Ingress.
-    host:
-    # -- The custom annotations that should be applied to the Ingress.
-    annotations: {}
-    # -- The port number of the ingress
-    port: 443
-    # -- The protocol scheme used by the browser to access the application.
-    # This is necessary so that the application generates the correct URLs.
-    # Note that, if present, the value of x-forwarded-proto header will override this setting.
-    scheme: https
-    # -- Set to true if the connection between the Ingress and the application should be considered secure.
-    secure: true
-
   clustering:
     # -- Set to true if Data Center clustering should be enabled
     # This will automatically configure cluster peer discovery between cluster nodes.
@@ -150,6 +134,22 @@ bitbucket:
   # -- Defines any additional environment variables to be passed to the Bitbucket container.
   # See https://hub.docker.com/r/atlassian/bitbucket-server for supported variables.
   additionalEnvironmentVariables: []
+
+ingress:
+  # -- True if an Ingress should be created.
+  create: false
+  # -- The fully-qualified hostname of the Ingress.
+  host:
+  # -- The custom annotations that should be applied to the Ingress.
+  annotations: {}
+  # -- The port number of the ingress
+  port: 443
+  # -- The protocol scheme used by the browser to access the application.
+  # This is necessary so that the application generates the correct URLs.
+  # Note that, if present, the value of x-forwarded-proto header will override this setting.
+  scheme: https
+  # -- Set to true if the connection between the Ingress and the application should be considered secure.
+  secure: true
 
 # -- Specify custom annotations to be added to all Bitbucket pods
 podAnnotations: {}

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -82,8 +82,12 @@ bitbucket:
     emailAddressSecretKey: emailAddress
 
   ingress:
-    # -- The fully-qualified domain name of the ingress
-    fqdn:
+    # -- True if an Ingress should be created.
+    create: false
+    # -- The fully-qualified hostname of the Ingress.
+    host:
+    # -- The custom annotations that should be applied to the Ingress.
+    annotations: {}
     # -- The port number of the ingress
     port: 443
     # -- The protocol scheme used by the browser to access the application.

--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -29,8 +29,6 @@ Kubernetes: `>=1.17.x-0`
 | confluence.additionalVolumeMounts | list | `[]` | Defines any additional volumes mounts for the Confluence container. These can refer to existing volumes, or new volumes can be defined in volumes.additional. |
 | confluence.clustering.enabled | bool | `false` | Set to true if Data Center clustering should be enabled This will automatically configure cluster peer discovery between cluster nodes. |
 | confluence.gid | string | `"2002"` | The GID used by the Confluence docker image |
-| confluence.ingress.scheme | string | `"https"` | The protocol scheme used by the browser to access the application. This is necessary so that the application generates the correct URLs. |
-| confluence.ingress.secure | bool | `true` | Set to true if the connection between the Ingress and the application should be considered secure. |
 | confluence.license.secretKey | string | `"license-key"` | The key in the Kubernetes Secret which contains the Confluence license key |
 | confluence.license.secretName | string | `nil` | The name of the Kubernetes Secret which contains the Confluence license key. If specified, then the license will be automatically populated during Confluence setup. Otherwise, it will need to be provided via the browser after initial startup. |
 | confluence.ports.hazelcast | int | `5701` | The port on which the Confluence container listens for Hazelcast traffic |
@@ -52,6 +50,11 @@ Kubernetes: `>=1.17.x-0`
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"atlassian/confluence-server"` |  |
 | image.tag | string | `nil` | The docker image tag to be used. Defaults to the Chart appVersion. |
+| ingress.annotations | object | `{}` | The custom annotations that should be applied to the Ingress. |
+| ingress.create | bool | `false` | True if an Ingress should be created. |
+| ingress.host | string | `nil` | The fully-qualified hostname of the Ingress. |
+| ingress.scheme | string | `"https"` | The protocol scheme used by the browser to access the application. This is necessary so that the application generates the correct URLs. |
+| ingress.secure | bool | `true` | Set to true if the connection between the Ingress and the application should be considered secure. |
 | nodeSelector | object | `{}` | Standard Kubernetes node-selectors that will be applied to all Confluence and Synchrony pods |
 | podAnnotations | object | `{}` | Specify additional annotations to be added to all Confluence and Synchrony pods |
 | replicaCount | int | `1` | The initial number of pods that should be started at deployment of each of Confluence and Synchrony. Note that because Confluence requires initial manual configuration after the first pod is deployed, and before scaling up to additional pods, this should always be kept as 1. |

--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -53,6 +53,7 @@ Kubernetes: `>=1.17.x-0`
 | ingress.annotations | object | `{}` | The custom annotations that should be applied to the Ingress. |
 | ingress.create | bool | `false` | True if an Ingress should be created. |
 | ingress.host | string | `nil` | The fully-qualified hostname of the Ingress. |
+| ingress.nginx | bool | `true` | True if the created Ingress is to use the Kubernetes ingress-nginx controller. This will populate the Ingress with annotations for that controller. Set to false if a different controller is to be used, in which case the annotations need to be specified. |
 | ingress.scheme | string | `"https"` | The protocol scheme used by the browser to access the application. This is necessary so that the application generates the correct URLs. |
 | ingress.secure | bool | `true` | Set to true if the connection between the Ingress and the application should be considered secure. |
 | nodeSelector | object | `{}` | Standard Kubernetes node-selectors that will be applied to all Confluence and Synchrony pods |

--- a/src/main/charts/confluence/templates/ingress.yaml
+++ b/src/main/charts/confluence/templates/ingress.yaml
@@ -1,17 +1,17 @@
-{{- if .Values.confluence.ingress.create }}
+{{- if .Values.ingress.create }}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "confluence.fullname" . }}
   labels:
     {{- include "confluence.labels" . | nindent 4 }}
-  {{- with .Values.confluence.ingress.annotations }}
+  {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   rules:
-    - host: {{ .Values.confluence.ingress.host }}
+    - host: {{ .Values.ingress.host }}
       http:
         paths:
           - path: "/"

--- a/src/main/charts/confluence/templates/ingress.yaml
+++ b/src/main/charts/confluence/templates/ingress.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.confluence.ingress.create }}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "confluence.fullname" . }}
+  labels:
+    {{- include "confluence.labels" . | nindent 4 }}
+  {{- with .Values.confluence.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  rules:
+    - host: {{ .Values.confluence.ingress.host }}
+      http:
+        paths:
+          - path: "/"
+            backend:
+              serviceName: {{ include "confluence.fullname" . }}
+              servicePort: {{ $.Values.confluence.service.port }}
+          {{ if .Values.synchrony.enabled }}
+          - path: "/synchrony"
+            backend:
+              serviceName: {{ include "synchrony.fullname" . }}
+              servicePort: {{ $.Values.synchrony.service.port }}
+          {{ end }}
+{{ end }}

--- a/src/main/charts/confluence/templates/ingress.yaml
+++ b/src/main/charts/confluence/templates/ingress.yaml
@@ -5,9 +5,17 @@ metadata:
   name: {{ include "confluence.fullname" . }}
   labels:
     {{- include "confluence.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{ if .Values.ingress.nginx }}
+    "kubernetes.io/ingress.class": "nginx"
+    "nginx.ingress.kubernetes.io/affinity": "cookie"
+    "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
+    "nginx.ingress.kubernetes.io/proxy-connect-timeout": "60"
+    "nginx.ingress.kubernetes.io/proxy-read-timeout": "60"
+    "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
+    {{- end }}
+    {{- with .Values.ingress.annotations }}
+  {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   rules:

--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -66,9 +66,9 @@ spec:
             {{- include "confluence.additionalBundledPlugins" . | nindent 12 }}
           env:
             - name: ATL_TOMCAT_SCHEME
-              value: {{ .Values.confluence.ingress.scheme | quote }}
+              value: {{ .Values.ingress.scheme | quote }}
             - name: ATL_TOMCAT_SECURE
-              value: {{ .Values.confluence.ingress.secure | quote }}
+              value: {{ .Values.ingress.secure | quote }}
             - name: ATL_PRODUCT_HOME_SHARED
               value: {{ .Values.volumes.sharedHome.mountPath | quote }}
             - name: JVM_SUPPORT_RECOMMENDED_ARGS

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -62,18 +62,6 @@ confluence:
     http: 8090
     # -- The port on which the Confluence container listens for Hazelcast traffic
     hazelcast: 5701
-  ingress:
-    # -- True if an Ingress should be created.
-    create: false
-    # -- The fully-qualified hostname of the Ingress.
-    host:
-    # -- The custom annotations that should be applied to the Ingress.
-    annotations: {}
-    # -- The protocol scheme used by the browser to access the application.
-    # This is necessary so that the application generates the correct URLs.
-    scheme: https
-    # -- Set to true if the connection between the Ingress and the application should be considered secure.
-    secure: true
   license:
     # -- The name of the Kubernetes Secret which contains the Confluence license key.
     # If specified, then the license will be automatically populated during Confluence setup.
@@ -171,6 +159,19 @@ synchrony:
   # Confluence service will use to communicate directly with Synchrony, so the URL must be resovable both from inside and
   # outside the Kubernetes cluster.
   ingressUrl:
+
+ingress:
+  # -- True if an Ingress should be created.
+  create: false
+  # -- The fully-qualified hostname of the Ingress.
+  host:
+  # -- The custom annotations that should be applied to the Ingress.
+  annotations: {}
+  # -- The protocol scheme used by the browser to access the application.
+  # This is necessary so that the application generates the correct URLs.
+  scheme: https
+  # -- Set to true if the connection between the Ingress and the application should be considered secure.
+  secure: true
 
 # -- Specify additional annotations to be added to all Confluence and Synchrony pods
 podAnnotations: {}

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -63,6 +63,12 @@ confluence:
     # -- The port on which the Confluence container listens for Hazelcast traffic
     hazelcast: 5701
   ingress:
+    # -- True if an Ingress should be created.
+    create: false
+    # -- The fully-qualified hostname of the Ingress.
+    host:
+    # -- The custom annotations that should be applied to the Ingress.
+    annotations: {}
     # -- The protocol scheme used by the browser to access the application.
     # This is necessary so that the application generates the correct URLs.
     scheme: https

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -163,6 +163,10 @@ synchrony:
 ingress:
   # -- True if an Ingress should be created.
   create: false
+  # -- True if the created Ingress is to use the Kubernetes ingress-nginx controller.
+  # This will populate the Ingress with annotations for that controller.
+  # Set to false if a different controller is to be used, in which case the annotations need to be specified.
+  nginx: true
   # -- The fully-qualified hostname of the Ingress.
   host:
   # -- The custom annotations that should be applied to the Ingress.

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -31,6 +31,11 @@ Kubernetes: `>=1.17.x-0`
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"atlassian/jira-software"` |  |
 | image.tag | string | `""` | The docker image tag to be used. Defaults to the Chart appVersion. |
+| ingress.annotations | object | `{}` | The custom annotations that should be applied to the Ingress. |
+| ingress.create | bool | `false` | True if an Ingress should be created. |
+| ingress.host | string | `nil` | The fully-qualified hostname of the Ingress. |
+| ingress.scheme | string | `"https"` | The protocol scheme used by the browser to access the application. This is necessary so that the application generates the correct URLs. |
+| ingress.secure | bool | `true` | Set to true if the connection between the Ingress and the application should be considered secure. |
 | jira.additionalBundledPlugins | list | `[]` | Specifies a list of additional Jira plugins that should be added to the Jira container. These are specified in the same manner as the additionalLibraries field, but the files will be loaded as bundled plugins rather than as libraries. |
 | jira.additionalEnvironmentVariables | list | `[]` | Defines any additional environment variables to be passed to the Jira container. See https://hub.docker.com/r/atlassian/jira-software for supported variables. |
 | jira.additionalJvmArgs | string | `nil` | Specifies a list of additional arguments that can be passed to the Jira JVM, e.g. system properties |
@@ -38,8 +43,6 @@ Kubernetes: `>=1.17.x-0`
 | jira.additionalVolumeMounts | list | `[]` | Defines any additional volumes mounts for the Jira container. These can refer to existing volumes, or new volumes can be defined in volumes.additional. |
 | jira.clustering.enabled | bool | `false` | Set to true if Data Center clustering should be enabled This will automatically configure cluster peer discovery between cluster nodes. |
 | jira.gid | string | `"2001"` | The GID used by the Jira docker image |
-| jira.ingress.scheme | string | `"https"` | The protocol scheme used by the browser to access the application. This is necessary so that the application generates the correct URLs. |
-| jira.ingress.secure | bool | `true` | Set to true if the connection between the Ingress and the application should be considered secure. |
 | jira.ports.http | int | `8080` | The port on which the Jira container listens for HTTP traffic |
 | jira.readinessProbe.failureThreshold | int | `30` | The number of consecutive failures of the Jira container readiness probe before the pod fails readiness checks |
 | jira.readinessProbe.initialDelaySeconds | int | `10` | The initial delay (in seconds) for the Jira container readiness probe, after which the probe will start running |

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -34,6 +34,7 @@ Kubernetes: `>=1.17.x-0`
 | ingress.annotations | object | `{}` | The custom annotations that should be applied to the Ingress. |
 | ingress.create | bool | `false` | True if an Ingress should be created. |
 | ingress.host | string | `nil` | The fully-qualified hostname of the Ingress. |
+| ingress.nginx | bool | `true` | True if the created Ingress is to use the Kubernetes ingress-nginx controller. This will populate the Ingress with annotations for that controller. Set to false if a different controller is to be used, in which case the annotations need to be specified. |
 | ingress.scheme | string | `"https"` | The protocol scheme used by the browser to access the application. This is necessary so that the application generates the correct URLs. |
 | ingress.secure | bool | `true` | Set to true if the connection between the Ingress and the application should be considered secure. |
 | jira.additionalBundledPlugins | list | `[]` | Specifies a list of additional Jira plugins that should be added to the Jira container. These are specified in the same manner as the additionalLibraries field, but the files will be loaded as bundled plugins rather than as libraries. |

--- a/src/main/charts/jira/templates/ingress.yaml
+++ b/src/main/charts/jira/templates/ingress.yaml
@@ -5,9 +5,17 @@ metadata:
   name: {{ include "jira.fullname" . }}
   labels:
     {{- include "jira.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{ if .Values.ingress.nginx }}
+    "kubernetes.io/ingress.class": "nginx"
+    "nginx.ingress.kubernetes.io/affinity": "cookie"
+    "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
+    "nginx.ingress.kubernetes.io/proxy-connect-timeout": "60"
+    "nginx.ingress.kubernetes.io/proxy-read-timeout": "60"
+    "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
+    {{- end }}
+    {{- with .Values.ingress.annotations }}
+  {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   rules:

--- a/src/main/charts/jira/templates/ingress.yaml
+++ b/src/main/charts/jira/templates/ingress.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.jira.ingress.create }}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "jira.fullname" . }}
+  labels:
+    {{- include "jira.labels" . | nindent 4 }}
+  {{- with .Values.jira.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  rules:
+    - host: {{ .Values.jira.ingress.host }}
+      http:
+        paths:
+          - path: "/"
+            backend:
+              serviceName: {{ include "jira.fullname" $ }}
+              servicePort: {{ $.Values.jira.service.port }}
+{{ end }}

--- a/src/main/charts/jira/templates/ingress.yaml
+++ b/src/main/charts/jira/templates/ingress.yaml
@@ -1,17 +1,17 @@
-{{- if .Values.jira.ingress.create }}
+{{- if .Values.ingress.create }}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "jira.fullname" . }}
   labels:
     {{- include "jira.labels" . | nindent 4 }}
-  {{- with .Values.jira.ingress.annotations }}
+  {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   rules:
-    - host: {{ .Values.jira.ingress.host }}
+    - host: {{ .Values.ingress.host }}
       http:
         paths:
           - path: "/"

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -35,9 +35,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: ATL_TOMCAT_SCHEME
-              value: {{ .Values.jira.ingress.scheme | quote }}
+              value: {{ .Values.ingress.scheme | quote }}
             - name: ATL_TOMCAT_SECURE
-              value: {{ .Values.jira.ingress.secure | quote }}
+              value: {{ .Values.ingress.secure | quote }}
             {{- include "jira.databaseEnvVars" . | nindent 12 }}
             {{- include "jira.clusteringEnvVars" . | nindent 12 }}
             - name: JIRA_SHARED_HOME

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -52,18 +52,6 @@ jira:
   ports:
     # -- The port on which the Jira container listens for HTTP traffic
     http: 8080
-  ingress:
-    # -- True if an Ingress should be created.
-    create: false
-    # -- The fully-qualified hostname of the Ingress.
-    host:
-    # -- The custom annotations that should be applied to the Ingress.
-    annotations: {}
-    # -- The protocol scheme used by the browser to access the application.
-    # This is necessary so that the application generates the correct URLs.
-    scheme: https
-    # -- Set to true if the connection between the Ingress and the application should be considered secure.
-    secure: true
   readinessProbe:
     # -- The initial delay (in seconds) for the Jira container readiness probe, after which the probe will start running
     initialDelaySeconds: 10
@@ -126,6 +114,19 @@ jira:
   # -- Defines any additional environment variables to be passed to the Jira container.
   # See https://hub.docker.com/r/atlassian/jira-software for supported variables.
   additionalEnvironmentVariables: []
+
+ingress:
+  # -- True if an Ingress should be created.
+  create: false
+  # -- The fully-qualified hostname of the Ingress.
+  host:
+  # -- The custom annotations that should be applied to the Ingress.
+  annotations: {}
+  # -- The protocol scheme used by the browser to access the application.
+  # This is necessary so that the application generates the correct URLs.
+  scheme: https
+  # -- Set to true if the connection between the Ingress and the application should be considered secure.
+  secure: true
 
 # -- Specify custom annotations to be added to all Jira pods
 podAnnotations: {}

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -53,6 +53,12 @@ jira:
     # -- The port on which the Jira container listens for HTTP traffic
     http: 8080
   ingress:
+    # -- True if an Ingress should be created.
+    create: false
+    # -- The fully-qualified hostname of the Ingress.
+    host:
+    # -- The custom annotations that should be applied to the Ingress.
+    annotations: {}
     # -- The protocol scheme used by the browser to access the application.
     # This is necessary so that the application generates the correct URLs.
     scheme: https

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -118,6 +118,10 @@ jira:
 ingress:
   # -- True if an Ingress should be created.
   create: false
+  # -- True if the created Ingress is to use the Kubernetes ingress-nginx controller.
+  # This will populate the Ingress with annotations for that controller.
+  # Set to false if a different controller is to be used, in which case the annotations need to be specified.
+  nginx: true
   # -- The fully-qualified hostname of the Ingress.
   host:
   # -- The custom annotations that should be applied to the Ingress.

--- a/src/test/charts/functest/templates/ingress-EKS.yaml
+++ b/src/test/charts/functest/templates/ingress-EKS.yaml
@@ -1,8 +1,8 @@
-{{- if eq "EKS" .Values.clusterType }}
+{{- if and (eq "EKS" .Values.clusterType) .Values.backdoorServiceNames }}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Values.productReleaseName }}
+  name: {{ .Release.Name | quote }}
   labels:
     "app.kubernetes.io/managed-by": "Helm"
     "meta.helm.sh/release-name": {{ .Release.Name | quote }}
@@ -16,7 +16,7 @@ metadata:
     "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
 spec:
   rules:
-    {{- range $serviceName := .Values.ingressNames }}
+    {{- range $serviceName := .Values.backdoorServiceNames }}
     - host: {{ printf "%s.%s" $serviceName $.Values.ingressDomain }}
       http:
         paths:

--- a/src/test/config/bitbucket/values-EKS.yaml
+++ b/src/test/config/bitbucket/values-EKS.yaml
@@ -3,17 +3,16 @@ serviceAccount:
   imagePullSecrets:
     - name: regcred
 
-bitbucket:
-  ingress:
-    create: true
-    host: ${helm.release.prefix}-bitbucket.${eks.ingress.domain}
-    annotations:
-      "kubernetes.io/ingress.class": "nginx"
-      "nginx.ingress.kubernetes.io/affinity": "cookie"
-      "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
-      "nginx.ingress.kubernetes.io/proxy-connect-timeout": "60"
-      "nginx.ingress.kubernetes.io/proxy-read-timeout": "60"
-      "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
+ingress:
+  create: true
+  host: ${helm.release.prefix}-bitbucket.${eks.ingress.domain}
+  annotations:
+    "kubernetes.io/ingress.class": "nginx"
+    "nginx.ingress.kubernetes.io/affinity": "cookie"
+    "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
+    "nginx.ingress.kubernetes.io/proxy-connect-timeout": "60"
+    "nginx.ingress.kubernetes.io/proxy-read-timeout": "60"
+    "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
 
 volumes:
   localHome:

--- a/src/test/config/bitbucket/values-EKS.yaml
+++ b/src/test/config/bitbucket/values-EKS.yaml
@@ -5,7 +5,15 @@ serviceAccount:
 
 bitbucket:
   ingress:
-    fqdn: ${helm.release.prefix}-bitbucket.${eks.ingress.domain}
+    create: true
+    host: ${helm.release.prefix}-bitbucket.${eks.ingress.domain}
+    annotations:
+      "kubernetes.io/ingress.class": "nginx"
+      "nginx.ingress.kubernetes.io/affinity": "cookie"
+      "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
+      "nginx.ingress.kubernetes.io/proxy-connect-timeout": "60"
+      "nginx.ingress.kubernetes.io/proxy-read-timeout": "60"
+      "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
 
 volumes:
   localHome:

--- a/src/test/config/bitbucket/values-EKS.yaml
+++ b/src/test/config/bitbucket/values-EKS.yaml
@@ -6,13 +6,6 @@ serviceAccount:
 ingress:
   create: true
   host: ${helm.release.prefix}-bitbucket.${eks.ingress.domain}
-  annotations:
-    "kubernetes.io/ingress.class": "nginx"
-    "nginx.ingress.kubernetes.io/affinity": "cookie"
-    "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
-    "nginx.ingress.kubernetes.io/proxy-connect-timeout": "60"
-    "nginx.ingress.kubernetes.io/proxy-read-timeout": "60"
-    "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
 
 volumes:
   localHome:

--- a/src/test/config/bitbucket/values-KITT.yaml
+++ b/src/test/config/bitbucket/values-KITT.yaml
@@ -11,9 +11,8 @@ serviceAccount:
 podAnnotations:
   "atlassian.com/business_unit": "server_engineering"
 
-bitbucket:
-  ingress:
-    host: ${helm.release.prefix}-bitbucket.${kitt.ingress.domain}
+ingress:
+  host: ${helm.release.prefix}-bitbucket.${kitt.ingress.domain}
 
 volumes:
   localHome:

--- a/src/test/config/bitbucket/values-KITT.yaml
+++ b/src/test/config/bitbucket/values-KITT.yaml
@@ -13,7 +13,7 @@ podAnnotations:
 
 bitbucket:
   ingress:
-    fqdn: ${helm.release.prefix}-bitbucket.${kitt.ingress.domain}
+    host: ${helm.release.prefix}-bitbucket.${kitt.ingress.domain}
 
 volumes:
   localHome:

--- a/src/test/config/confluence/values-EKS.yaml
+++ b/src/test/config/confluence/values-EKS.yaml
@@ -8,13 +8,6 @@ serviceAccount:
 ingress:
   create: true
   host: ${helm.release.prefix}-confluence.${eks.ingress.domain}
-  annotations:
-    "kubernetes.io/ingress.class": "nginx"
-    "nginx.ingress.kubernetes.io/affinity": "cookie"
-    "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
-    "nginx.ingress.kubernetes.io/proxy-connect-timeout": "60"
-    "nginx.ingress.kubernetes.io/proxy-read-timeout": "60"
-    "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
 
 synchrony:
   ingressUrl: https://${helm.release.prefix}-confluence.${eks.ingress.domain}/synchrony

--- a/src/test/config/confluence/values-EKS.yaml
+++ b/src/test/config/confluence/values-EKS.yaml
@@ -5,17 +5,16 @@ serviceAccount:
   imagePullSecrets:
     - name: regcred
 
-confluence:
-  ingress:
-    create: true
-    host: ${helm.release.prefix}-confluence.${eks.ingress.domain}
-    annotations:
-      "kubernetes.io/ingress.class": "nginx"
-      "nginx.ingress.kubernetes.io/affinity": "cookie"
-      "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
-      "nginx.ingress.kubernetes.io/proxy-connect-timeout": "60"
-      "nginx.ingress.kubernetes.io/proxy-read-timeout": "60"
-      "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
+ingress:
+  create: true
+  host: ${helm.release.prefix}-confluence.${eks.ingress.domain}
+  annotations:
+    "kubernetes.io/ingress.class": "nginx"
+    "nginx.ingress.kubernetes.io/affinity": "cookie"
+    "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
+    "nginx.ingress.kubernetes.io/proxy-connect-timeout": "60"
+    "nginx.ingress.kubernetes.io/proxy-read-timeout": "60"
+    "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
 
 synchrony:
   ingressUrl: https://${helm.release.prefix}-confluence.${eks.ingress.domain}/synchrony

--- a/src/test/config/confluence/values-EKS.yaml
+++ b/src/test/config/confluence/values-EKS.yaml
@@ -5,6 +5,18 @@ serviceAccount:
   imagePullSecrets:
     - name: regcred
 
+confluence:
+  ingress:
+    create: true
+    host: ${helm.release.prefix}-confluence.${eks.ingress.domain}
+    annotations:
+      "kubernetes.io/ingress.class": "nginx"
+      "nginx.ingress.kubernetes.io/affinity": "cookie"
+      "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
+      "nginx.ingress.kubernetes.io/proxy-connect-timeout": "60"
+      "nginx.ingress.kubernetes.io/proxy-read-timeout": "60"
+      "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
+
 synchrony:
   ingressUrl: https://${helm.release.prefix}-confluence.${eks.ingress.domain}/synchrony
 

--- a/src/test/config/jira/values-EKS.yaml
+++ b/src/test/config/jira/values-EKS.yaml
@@ -5,6 +5,18 @@ serviceAccount:
   imagePullSecrets:
     - name: regcred
 
+jira:
+  ingress:
+    create: true
+    host: ${helm.release.prefix}-jira.${eks.ingress.domain}
+    annotations:
+      "kubernetes.io/ingress.class": "nginx"
+      "nginx.ingress.kubernetes.io/affinity": "cookie"
+      "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
+      "nginx.ingress.kubernetes.io/proxy-connect-timeout": "60"
+      "nginx.ingress.kubernetes.io/proxy-read-timeout": "60"
+      "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
+
 volumes:
   localHome:
     persistentVolumeClaim:

--- a/src/test/config/jira/values-EKS.yaml
+++ b/src/test/config/jira/values-EKS.yaml
@@ -5,17 +5,16 @@ serviceAccount:
   imagePullSecrets:
     - name: regcred
 
-jira:
-  ingress:
-    create: true
-    host: ${helm.release.prefix}-jira.${eks.ingress.domain}
-    annotations:
-      "kubernetes.io/ingress.class": "nginx"
-      "nginx.ingress.kubernetes.io/affinity": "cookie"
-      "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
-      "nginx.ingress.kubernetes.io/proxy-connect-timeout": "60"
-      "nginx.ingress.kubernetes.io/proxy-read-timeout": "60"
-      "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
+ingress:
+  create: true
+  host: ${helm.release.prefix}-jira.${eks.ingress.domain}
+  annotations:
+    "kubernetes.io/ingress.class": "nginx"
+    "nginx.ingress.kubernetes.io/affinity": "cookie"
+    "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
+    "nginx.ingress.kubernetes.io/proxy-connect-timeout": "60"
+    "nginx.ingress.kubernetes.io/proxy-read-timeout": "60"
+    "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
 
 volumes:
   localHome:

--- a/src/test/config/jira/values-EKS.yaml
+++ b/src/test/config/jira/values-EKS.yaml
@@ -8,13 +8,6 @@ serviceAccount:
 ingress:
   create: true
   host: ${helm.release.prefix}-jira.${eks.ingress.domain}
-  annotations:
-    "kubernetes.io/ingress.class": "nginx"
-    "nginx.ingress.kubernetes.io/affinity": "cookie"
-    "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
-    "nginx.ingress.kubernetes.io/proxy-connect-timeout": "60"
-    "nginx.ingress.kubernetes.io/proxy-read-timeout": "60"
-    "nginx.ingress.kubernetes.io/proxy-send-timeout": "60"
 
 volumes:
   localHome:

--- a/src/test/java/test/IngressTest.java
+++ b/src/test/java/test/IngressTest.java
@@ -25,8 +25,8 @@ class IngressTest {
     @EnumSource
     void ingress_create(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
-                product + ".ingress.create", "true",
-                product + ".ingress.host", "myhost.mydomain"));
+                "ingress.create", "true",
+                "ingress.host", "myhost.mydomain"));
 
         final var ingress = resources.get(Kind.Ingress);
 
@@ -38,8 +38,8 @@ class IngressTest {
     @EnumSource(value = Product.class, mode = EXCLUDE, names = "bitbucket")
     void https_disabled(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
-                product + ".ingress.secure", "false",
-                product + ".ingress.scheme", "http"));
+                "ingress.secure", "false",
+                "ingress.scheme", "http"));
 
         resources.getStatefulSet(product.getHelmReleaseName())
                 .getContainer()
@@ -52,8 +52,8 @@ class IngressTest {
     @EnumSource(value = Product.class, names = "bitbucket")
     void https_disabled_bitbucket(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
-                product + ".ingress.secure", "false",
-                product + ".ingress.scheme", "http"));
+                "ingress.secure", "false",
+                "ingress.scheme", "http"));
 
         resources.getStatefulSet(product.getHelmReleaseName())
                 .getContainer()

--- a/src/test/java/test/IngressTest.java
+++ b/src/test/java/test/IngressTest.java
@@ -32,6 +32,9 @@ class IngressTest {
 
         assertThat(ingress.getNode("spec", "rules").required(0).path("host"))
                 .hasTextContaining("myhost.mydomain");
+
+        assertThat(ingress.getMetadata().path("annotations"))
+                .isObject(Map.of("kubernetes.io/ingress.class", "nginx"));
     }
 
     @ParameterizedTest

--- a/src/test/java/test/IngressTest.java
+++ b/src/test/java/test/IngressTest.java
@@ -5,11 +5,13 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import test.helm.Helm;
+import test.model.Kind;
 import test.model.Product;
 
 import java.util.Map;
 
 import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
+import static test.jackson.JsonNodeAssert.assertThat;
 
 class IngressTest {
     private Helm helm;
@@ -17,6 +19,19 @@ class IngressTest {
     @BeforeEach
     void initHelm(TestInfo testInfo) {
         helm = new Helm(testInfo);
+    }
+
+    @ParameterizedTest
+    @EnumSource
+    void ingress_create(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                product + ".ingress.create", "true",
+                product + ".ingress.host", "myhost.mydomain"));
+
+        final var ingress = resources.get(Kind.Ingress);
+
+        assertThat(ingress.getNode("spec", "rules").required(0).path("host"))
+                .hasTextContaining("myhost.mydomain");
     }
 
     @ParameterizedTest

--- a/src/test/java/test/model/Kind.java
+++ b/src/test/java/test/model/Kind.java
@@ -4,5 +4,5 @@ package test.model;
  * The different types of Kubernetes resource we use.
  */
 public enum Kind {
-    StatefulSet, ServiceAccount, ConfigMap, Service, Pod, Job, ClusterRole, ClusterRoleBinding, PersistentVolumeClaim
+    StatefulSet, ServiceAccount, ConfigMap, Service, Pod, Job, ClusterRole, ClusterRoleBinding, PersistentVolumeClaim, Ingress
 }


### PR DESCRIPTION
After much head-scratching about how Ingresses are defined across different Kubernetes API versions, I've added an Ingress template to each of our Helm charts.

By default, the Ingress is not created, the customer will have to set the `create` value to `true`. The customer also has to specify the `host` value, plus the annotations corresponding to the specific Ingress controller that the customer hapens to be using, e.g. ingress-nginx.

Also, because we use ingress-nginx in our EKS cluster, we can use (and test) these new Ingress templates in our EKS bamboo jobs. The KITT jobs still need to create the custom Contour Ingresses in the functest chart.