### PR TITLE
DCNG-892 simplify config of https/http

### DIFF
--- a/src/main/charts/bitbucket/templates/_helpers.tpl
+++ b/src/main/charts/bitbucket/templates/_helpers.tpl
@@ -102,10 +102,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{- define "bitbucket.baseUrl" -}}
-{{ $httpPortMismatch := (and (eq .Values.ingress.scheme "http") (ne (int .Values.ingress.port) 80) ) -}}
-{{ $httpsPortMismatch := (and (eq .Values.ingress.scheme "https") (ne (int .Values.ingress.port) 443) ) -}}
-{{ .Values.ingress.scheme }}://{{ .Values.ingress.host -}}
-{{ if or $httpPortMismatch $httpsPortMismatch }}:{{ .Values.ingress.port }}{{ end }}
+{{ ternary "https" "http" .Values.ingress.https -}}
+://
+{{- .Values.ingress.host -}}
+{{ with .Values.ingress.port }}:{{ . }}{{ end }}
+{{- end }}
+
+{{- define "bitbucket.ingressPort" -}}
+{{ default (ternary "443" "80" .Values.ingress.https) .Values.ingress.port -}}
 {{- end }}
 
 {{/*

--- a/src/main/charts/bitbucket/templates/statefulset.yaml
+++ b/src/main/charts/bitbucket/templates/statefulset.yaml
@@ -76,15 +76,17 @@ spec:
             {{ if .Values.ingress.host }}
             - name: SERVER_PROXY_NAME
               value: {{ .Values.ingress.host | quote }}
+            - name: SERVER_PROXY_PORT
+              value: {{ include "bitbucket.ingressPort" . | quote }}
             - name: SETUP_BASEURL
               value: {{ include "bitbucket.baseUrl" . | quote }}
             {{ end }}
-            - name: SERVER_PROXY_PORT
-              value: {{ .Values.ingress.port | quote }}
+            {{ if .Values.ingress.https }}
             - name: SERVER_SCHEME
-              value: {{ .Values.ingress.scheme | quote }}
+              value: "https"
             - name: SERVER_SECURE
-              value: {{ .Values.ingress.secure | quote }}
+              value: "true"
+            {{ end }}
             - name: BITBUCKET_SHARED_HOME
               value: {{ .Values.volumes.sharedHome.mountPath | quote }}
             {{ with .Values.bitbucket.license.secretName }}

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -158,14 +158,10 @@ ingress:
   host:
   # -- The custom annotations that should be applied to the Ingress.
   annotations: {}
-  # -- The port number of the ingress
-  port: 443
-  # -- The protocol scheme used by the browser to access the application.
-  # This is necessary so that the application generates the correct URLs.
-  # Note that, if present, the value of x-forwarded-proto header will override this setting.
-  scheme: https
-  # -- Set to true if the connection between the Ingress and the application should be considered secure.
-  secure: true
+  # -- True if the browser communicates with the application over HTTPS.
+  https: true
+  # -- Used to specify a custom port number for the ingress.
+  port:
 
 # -- Specify custom annotations to be added to all Bitbucket pods
 podAnnotations: {}

--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -65,10 +65,12 @@ spec:
             {{- include "confluence.additionalLibraries" . | nindent 12 }}
             {{- include "confluence.additionalBundledPlugins" . | nindent 12 }}
           env:
+            {{ if .Values.ingress.https }}
             - name: ATL_TOMCAT_SCHEME
-              value: {{ .Values.ingress.scheme | quote }}
+              value: "https"
             - name: ATL_TOMCAT_SECURE
-              value: {{ .Values.ingress.secure | quote }}
+              value: "true"
+            {{ end }}
             - name: ATL_PRODUCT_HOME_SHARED
               value: {{ .Values.volumes.sharedHome.mountPath | quote }}
             - name: JVM_SUPPORT_RECOMMENDED_ARGS

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -171,11 +171,8 @@ ingress:
   host:
   # -- The custom annotations that should be applied to the Ingress.
   annotations: {}
-  # -- The protocol scheme used by the browser to access the application.
-  # This is necessary so that the application generates the correct URLs.
-  scheme: https
-  # -- Set to true if the connection between the Ingress and the application should be considered secure.
-  secure: true
+  # -- True if the browser communicates with the application over HTTPS.
+  https: true
 
 # -- Specify additional annotations to be added to all Confluence and Synchrony pods
 podAnnotations: {}

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -34,10 +34,12 @@ spec:
           image: {{ include "jira.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            {{ if .Values.ingress.https }}
             - name: ATL_TOMCAT_SCHEME
-              value: {{ .Values.ingress.scheme | quote }}
+              value: "https"
             - name: ATL_TOMCAT_SECURE
-              value: {{ .Values.ingress.secure | quote }}
+              value: "true"
+              {{ end }}
             {{- include "jira.databaseEnvVars" . | nindent 12 }}
             {{- include "jira.clusteringEnvVars" . | nindent 12 }}
             - name: JIRA_SHARED_HOME

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -126,11 +126,8 @@ ingress:
   host:
   # -- The custom annotations that should be applied to the Ingress.
   annotations: {}
-  # -- The protocol scheme used by the browser to access the application.
-  # This is necessary so that the application generates the correct URLs.
-  scheme: https
-  # -- Set to true if the connection between the Ingress and the application should be considered secure.
-  secure: true
+  # -- True if the browser communicates with the application over HTTPS.
+  https: true
 
 # -- Specify custom annotations to be added to all Jira pods
 podAnnotations: {}

--- a/src/test/resources/expected_helm_output/bitbucket/output.yaml
+++ b/src/test/resources/expected_helm_output/bitbucket/output.yaml
@@ -114,8 +114,6 @@ spec:
             - name: shared-home
               mountPath: "/var/atlassian/application-data/shared-home"
           env:
-            - name: SERVER_PROXY_PORT
-              value: "443"
             - name: SERVER_SCHEME
               value: "https"
             - name: SERVER_SECURE


### PR DESCRIPTION
Currently, the charts have config values for the `SERVER_SCHEME` and `SERVER_SECURE` env vars. The values for these must be consistent, and are difficult to describe at the level of abstraction that the Helm charts operate at. There's no reason this can't be represented in the charts as a single boolean value, `https`, from which the 2 env vars can be derived.