### PR TITLE
Add optional TLS to ingress spec

### DIFF
--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -59,10 +59,10 @@ Kubernetes: `>=1.17.x-0`
 | ingress.annotations | object | `{}` | The custom annotations that should be applied to the Ingress. |
 | ingress.create | bool | `false` | True if an Ingress should be created. |
 | ingress.host | string | `nil` | The fully-qualified hostname of the Ingress. |
+| ingress.https | bool | `true` | True if the browser communicates with the application over HTTPS. |
 | ingress.nginx | bool | `true` | True if the created Ingress is to use the Kubernetes ingress-nginx controller. This will populate the Ingress with annotations for that controller. Set to false if a different controller is to be used, in which case the annotations need to be specified. |
-| ingress.port | int | `443` | The port number of the ingress |
-| ingress.scheme | string | `"https"` | The protocol scheme used by the browser to access the application. This is necessary so that the application generates the correct URLs. Note that, if present, the value of x-forwarded-proto header will override this setting. |
-| ingress.secure | bool | `true` | Set to true if the connection between the Ingress and the application should be considered secure. |
+| ingress.port | string | `nil` | Used to specify a custom port number for the ingress. |
+| ingress.tlsSecretName | string | `nil` | Secret that contains a TLS private key and certificate. Optional if Ingress Controller is configured to use one secret for all ingresses |
 | nodeSelector | object | `{}` | Standard Kubernetes node-selectors that will be applied to all Bitbucket pods |
 | podAnnotations | object | `{}` | Specify custom annotations to be added to all Bitbucket pods |
 | replicaCount | int | `1` | The initial number of pods that should be started at deployment of Bitbucket. |

--- a/src/main/charts/bitbucket/templates/ingress.yaml
+++ b/src/main/charts/bitbucket/templates/ingress.yaml
@@ -18,6 +18,12 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{ if and (.Values.ingress.tlsSecretName) (.Values.ingress.host) }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tlsSecretName }}
+{{ end }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -160,6 +160,9 @@ ingress:
   annotations: {}
   # -- True if the browser communicates with the application over HTTPS.
   https: true
+  # -- Secret that contains a TLS private key and certificate.
+  # Optional if Ingress Controller is configured to use one secret for all ingresses
+  tlsSecretName:
   # -- Used to specify a custom port number for the ingress.
   port:
 

--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -53,9 +53,9 @@ Kubernetes: `>=1.17.x-0`
 | ingress.annotations | object | `{}` | The custom annotations that should be applied to the Ingress. |
 | ingress.create | bool | `false` | True if an Ingress should be created. |
 | ingress.host | string | `nil` | The fully-qualified hostname of the Ingress. |
+| ingress.https | bool | `true` | True if the browser communicates with the application over HTTPS. |
 | ingress.nginx | bool | `true` | True if the created Ingress is to use the Kubernetes ingress-nginx controller. This will populate the Ingress with annotations for that controller. Set to false if a different controller is to be used, in which case the annotations need to be specified. |
-| ingress.scheme | string | `"https"` | The protocol scheme used by the browser to access the application. This is necessary so that the application generates the correct URLs. |
-| ingress.secure | bool | `true` | Set to true if the connection between the Ingress and the application should be considered secure. |
+| ingress.tlsSecretName | string | `nil` | Secret that contains a TLS private key and certificate. Optional if Ingress Controller is configured to use one secret for all ingresses |
 | nodeSelector | object | `{}` | Standard Kubernetes node-selectors that will be applied to all Confluence and Synchrony pods |
 | podAnnotations | object | `{}` | Specify additional annotations to be added to all Confluence and Synchrony pods |
 | replicaCount | int | `1` | The initial number of pods that should be started at deployment of each of Confluence and Synchrony. Note that because Confluence requires initial manual configuration after the first pod is deployed, and before scaling up to additional pods, this should always be kept as 1. |

--- a/src/main/charts/confluence/templates/ingress.yaml
+++ b/src/main/charts/confluence/templates/ingress.yaml
@@ -18,6 +18,12 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{ if and (.Values.ingress.tlsSecretName) (.Values.ingress.host) }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tlsSecretName }}
+{{ end }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -173,6 +173,9 @@ ingress:
   annotations: {}
   # -- True if the browser communicates with the application over HTTPS.
   https: true
+  # -- Secret that contains a TLS private key and certificate.
+  # Optional if Ingress Controller is configured to use one secret for all ingresses
+  tlsSecretName:
 
 # -- Specify additional annotations to be added to all Confluence and Synchrony pods
 podAnnotations: {}

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -34,9 +34,9 @@ Kubernetes: `>=1.17.x-0`
 | ingress.annotations | object | `{}` | The custom annotations that should be applied to the Ingress. |
 | ingress.create | bool | `false` | True if an Ingress should be created. |
 | ingress.host | string | `nil` | The fully-qualified hostname of the Ingress. |
+| ingress.https | bool | `true` | True if the browser communicates with the application over HTTPS. |
 | ingress.nginx | bool | `true` | True if the created Ingress is to use the Kubernetes ingress-nginx controller. This will populate the Ingress with annotations for that controller. Set to false if a different controller is to be used, in which case the annotations need to be specified. |
-| ingress.scheme | string | `"https"` | The protocol scheme used by the browser to access the application. This is necessary so that the application generates the correct URLs. |
-| ingress.secure | bool | `true` | Set to true if the connection between the Ingress and the application should be considered secure. |
+| ingress.tlsSecretName | string | `nil` | Secret that contains a TLS private key and certificate. Optional if Ingress Controller is configured to use one secret for all ingresses |
 | jira.additionalBundledPlugins | list | `[]` | Specifies a list of additional Jira plugins that should be added to the Jira container. These are specified in the same manner as the additionalLibraries field, but the files will be loaded as bundled plugins rather than as libraries. |
 | jira.additionalEnvironmentVariables | list | `[]` | Defines any additional environment variables to be passed to the Jira container. See https://hub.docker.com/r/atlassian/jira-software for supported variables. |
 | jira.additionalJvmArgs | string | `nil` | Specifies a list of additional arguments that can be passed to the Jira JVM, e.g. system properties |

--- a/src/main/charts/jira/templates/ingress.yaml
+++ b/src/main/charts/jira/templates/ingress.yaml
@@ -18,6 +18,12 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{ if and (.Values.ingress.tlsSecretName) (.Values.ingress.host) }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tlsSecretName }}
+{{ end }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -128,6 +128,9 @@ ingress:
   annotations: {}
   # -- True if the browser communicates with the application over HTTPS.
   https: true
+  # -- Secret that contains a TLS private key and certificate.
+  # Optional if Ingress Controller is configured to use one secret for all ingresses
+  tlsSecretName:
 
 # -- Specify custom annotations to be added to all Jira pods
 podAnnotations: {}

--- a/src/test/java/test/IngressTest.java
+++ b/src/test/java/test/IngressTest.java
@@ -38,6 +38,23 @@ class IngressTest {
     }
 
     @ParameterizedTest
+    @EnumSource
+    void ingress_create_tls (Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                "ingress.create", "true",
+                "ingress.tlsSecretName", "tls-secret",
+                "ingress.host", "myhost.mydomain"));
+
+        final var ingress = resources.get(Kind.Ingress);
+        assertThat(ingress.getNode("spec", "tls").required(0).path("hosts").required(0))
+                .hasTextContaining("myhost.mydomain");
+
+        assertThat(ingress.getNode("spec", "tls").required(0).path("secretName"))
+                .hasTextContaining("tls-secret");
+
+    }
+
+    @ParameterizedTest
     @EnumSource(value = Product.class, names = "bitbucket")
     void bitbucket_ingress_host(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(


### PR DESCRIPTION
This PR:
* adds optional TLS configuration to ingress spec. It's not uncommon that TLS secrets are used in Ingress spec (rather than the ingress controller is configured with a wildcard TLS secret). For example, this is convenient when using cert-manager.
* adds a simple test verifying host and secret are set in spec
* update helm docs