### PR TITLE
DCNG-869: In EKS run CI only on the ci-tagged nodes

### DIFF
--- a/src/test/config/bitbucket/values-EKS.yaml
+++ b/src/test/config/bitbucket/values-EKS.yaml
@@ -19,3 +19,6 @@ volumes:
     subPath: ${helm.release.prefix}-bitbucket # Since all of our pods share the same EFS PV, we use subpath mounts to prevent interference
     nfsPermissionFixer:
       enabled: true
+
+nodeSelector:
+  node_purpose: ci

--- a/src/test/config/confluence/values-EKS.yaml
+++ b/src/test/config/confluence/values-EKS.yaml
@@ -23,3 +23,6 @@ volumes:
     subPath: ${helm.release.prefix}-confluence # Since all of our pods share the same EFS PV, we use subpath mounts to prevent interference
     nfsPermissionFixer:
       enabled: true
+
+nodeSelector:
+  node_purpose: ci

--- a/src/test/config/jira/values-EKS.yaml
+++ b/src/test/config/jira/values-EKS.yaml
@@ -20,3 +20,6 @@ volumes:
     subPath: ${helm.release.prefix}-jira # Since all of our pods share the same EFS PV, we use subpath mounts to prevent interference
     nfsPermissionFixer:
       enabled: true
+
+nodeSelector:
+  node_purpose: ci


### PR DESCRIPTION
so that they do not interfere with performance tests.

When I used 
```
nodeSelector:
  node_purpose: ci 
```
[the tests passed](https://server-gdn-bamboo.internal.atlassian.com/browse/DCNG-K8SJIRA-468), while when I used 
```
nodeSelector:
  node_purpose: bitcoin-digging
```
[the tests failed](https://server-gdn-bamboo.internal.atlassian.com/browse/DCNG-K8SJIRA-469).