### PR TITLE
Link the current installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ whether it be a managed environment such as Amazon EKS, or a custom, on-premise 
 
 ## Documentation
 
-[Here](docs/INSTALL.md)
+[Here](INSTALL.md)
 
 ## Contributions
 


### PR DESCRIPTION
It looks like it was intended to link to `INSTALL.md` in the root folder.