### PR TITLE
DCNG-890 - Fix Bitbucket test failure for 2 nodes

### DIFF
--- a/src/test/config/bitbucket/helm_parameters
+++ b/src/test/config/bitbucket/helm_parameters
@@ -11,4 +11,6 @@ DOCKER_IMAGE_REGISTRY=${dockerImage.registry}
 DOCKER_IMAGE_VERSION=${dockerImage.version}
 INGRESS_DOMAIN_KITT=${kitt.ingress.domain}
 INGRESS_DOMAIN_EKS=${eks.ingress.domain}
+# .Values.replicaCount=1, but in here we specify how many nodes we are planning to get to prepare ingress rules for each
+TARGET_REPLICA_COUNT=2
 DB_INIT_SCRIPT_FILE=${db.init.script.file}

--- a/src/test/scripts/helm_uninstall.sh
+++ b/src/test/scripts/helm_uninstall.sh
@@ -26,9 +26,8 @@ if [ "$shouldCleanNfsPod" != true ]; then
 fi
 
 # delete any and all persistent volumes and claims by label
-# todo DCNG-947
 echo Deleting PVCs, if the uninstall script gets stuck deleting the shared pvc here, run:
-sharedPvcName=$(kubectl get -n dcng pvc -l app.kubernetes.io/instance=pbruski-bitbucket | grep shared | awk '{print $1;}')
+sharedPvcName=$(kubectl get -n dcng pvc -l app.kubernetes.io/instance=$PRODUCT_RELEASE_NAME | grep shared | awk '{print $1;}')
 echo kubectl patch pvc -n "${TARGET_NAMESPACE}" "$sharedPvcName" -p "'{\"metadata\":{\"finalizers\":null}}'"
 kubectl delete -n "${TARGET_NAMESPACE}" pvc -l app.kubernetes.io/instance="${PRODUCT_RELEASE_NAME}"
 echo Deleting PVs...


### PR DESCRIPTION
Surprise, surprise, we need direct node access for BB tests too (otherwise user deletion is problematic because it has -  an intended - cluster propagation delay).