### PR TITLE
use mount options from the PV definition

### DIFF
--- a/src/test/config/bitbucket/values-EKS.yaml
+++ b/src/test/config/bitbucket/values-EKS.yaml
@@ -14,15 +14,6 @@ volumes:
   sharedHome:
     persistentVolume:
       create: true
-      mountOptions:
-        - rw
-        - nfsvers=3
-        - lookupcache=pos
-        - noatime
-        - intr
-        - rsize=32768
-        - wsize=32768
-        - _netdev
       nfs:
         path: "/srv/nfs"
     persistentVolumeClaim:


### PR DESCRIPTION
Now that we have NFSv3 support in the cluster, we don't need any overrides.