### PR TITLE
DCKUBE-44: Generify parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,8 @@
         <kitt.ingress.domain>${kubernetes.ingress.domain}</kitt.ingress.domain>
         <eks.ingress.domain>dcngkube.bbsperf.com</eks.ingress.domain>
 
+        <shared.pvc.name>efs-claim</shared.pvc.name>
+
         <persistence.enabled>true</persistence.enabled>
 
         <db.init.script.file/>

--- a/src/test/config/bitbucket/values-KITT.yaml
+++ b/src/test/config/bitbucket/values-KITT.yaml
@@ -21,7 +21,7 @@ volumes:
   sharedHome:
     customVolume:
       persistentVolumeClaim:
-        claimName: efs-claim # Pre-provisioned, and shared by all of our pods
+        claimName: ${shared.pvc.name} # Pre-provisioned, and shared by all of our pods
     subPath: ${helm.release.prefix}-bitbucket # Since all of our pods share the same EFS PV, we use subpath mounts to prevent interference
     nfsPermissionFixer:
       enabled: true

--- a/src/test/config/confluence/values-EKS.yaml
+++ b/src/test/config/confluence/values-EKS.yaml
@@ -19,7 +19,7 @@ volumes:
   sharedHome:
     customVolume:
       persistentVolumeClaim:
-        claimName: efs-claim # Pre-provisioned, and shared by all of our pods
+        claimName: ${shared.pvc.name} # Pre-provisioned, and shared by all of our pods
     subPath: ${helm.release.prefix}-confluence # Since all of our pods share the same EFS PV, we use subpath mounts to prevent interference
     nfsPermissionFixer:
       enabled: true

--- a/src/test/config/confluence/values-KITT.yaml
+++ b/src/test/config/confluence/values-KITT.yaml
@@ -23,7 +23,7 @@ volumes:
   sharedHome:
     customVolume:
       persistentVolumeClaim:
-        claimName: efs-claim # Pre-provisioned, and shared by all of our pods
+        claimName: ${shared.pvc.name} # Pre-provisioned, and shared by all of our pods
     subPath: ${helm.release.prefix}-confluence # Since all of our pods share the same EFS PV, we use subpath mounts to prevent interference
     nfsPermissionFixer:
       enabled: true

--- a/src/test/config/jira/values-EKS.yaml
+++ b/src/test/config/jira/values-EKS.yaml
@@ -16,7 +16,7 @@ volumes:
   sharedHome:
     customVolume:
       persistentVolumeClaim:
-        claimName: efs-claim # Pre-provisioned, and shared by all of our pods
+        claimName: ${shared.pvc.name} # Pre-provisioned, and shared by all of our pods
     subPath: ${helm.release.prefix}-jira # Since all of our pods share the same EFS PV, we use subpath mounts to prevent interference
     nfsPermissionFixer:
       enabled: true

--- a/src/test/config/jira/values-KITT.yaml
+++ b/src/test/config/jira/values-KITT.yaml
@@ -20,7 +20,7 @@ volumes:
   sharedHome:
     customVolume:
       persistentVolumeClaim:
-        claimName: efs-claim # Pre-provisioned, and shared by all of our pods
+        claimName: ${shared.pvc.name} # Pre-provisioned, and shared by all of our pods
     subPath: ${helm.release.prefix}-jira # Since all of our pods share the same EFS PV, we use subpath mounts to prevent interference
     nfsPermissionFixer:
       enabled: true

--- a/src/test/resources/shared-home-browser.yaml
+++ b/src/test/resources/shared-home-browser.yaml
@@ -16,4 +16,4 @@ spec:
   volumes:
     - name: shared-home
       persistentVolumeClaim:
-        claimName: efs-claim
+        claimName: ${shared.pvc.name}

--- a/src/test/scripts/helm_install.sh
+++ b/src/test/scripts/helm_install.sh
@@ -121,7 +121,7 @@ helm package "$CHART_SRC_PATH" \
    --destination "$HELM_PACKAGE_DIR"
 
 # Install the product's Helm chart
-helm install -n "${TARGET_NAMESPACE}" --wait \
+helm install -n "${TARGET_NAMESPACE}" --wait --debug \
    "$PRODUCT_RELEASE_NAME" \
    ${valueOverrides} \
    "$HELM_PACKAGE_DIR/${PRODUCT_NAME}"-*.tgz >> $LOG_DOWNLOAD_DIR/helm_install_log.txt

--- a/src/test/scripts/helm_install.sh
+++ b/src/test/scripts/helm_install.sh
@@ -121,7 +121,7 @@ helm package "$CHART_SRC_PATH" \
    --destination "$HELM_PACKAGE_DIR"
 
 # Install the product's Helm chart
-helm install -n "${TARGET_NAMESPACE}" --wait --debug \
+helm install -n "${TARGET_NAMESPACE}" --wait \
    "$PRODUCT_RELEASE_NAME" \
    ${valueOverrides} \
    "$HELM_PACKAGE_DIR/${PRODUCT_NAME}"-*.tgz >> $LOG_DOWNLOAD_DIR/helm_install_log.txt

--- a/src/test/scripts/helm_uninstall.sh
+++ b/src/test/scripts/helm_uninstall.sh
@@ -27,7 +27,7 @@ fi
 
 # delete any and all persistent volumes and claims by label
 echo Deleting PVCs, if the uninstall script gets stuck deleting the shared pvc here, run:
-sharedPvcName=$(kubectl get -n dcng pvc -l app.kubernetes.io/instance=$PRODUCT_RELEASE_NAME | grep shared | awk '{print $1;}')
+sharedPvcName=$(kubectl get -n ${TARGET_NAMESPACE} pvc -l app.kubernetes.io/instance=$PRODUCT_RELEASE_NAME | grep shared | awk '{print $1;}')
 echo kubectl patch pvc -n "${TARGET_NAMESPACE}" "$sharedPvcName" -p "'{\"metadata\":{\"finalizers\":null}}'"
 kubectl delete -n "${TARGET_NAMESPACE}" pvc -l app.kubernetes.io/instance="${PRODUCT_RELEASE_NAME}"
 echo Deleting PVs...


### PR DESCRIPTION
Enable translation of the `values-KITT.yaml` file with different values to deploy in a different namespace.

Example:
`mvn clean install -Dshared.pvc.name=efs-pvc-dcd -Dkubernetes.target.namespace=dcd`