### PR TITLE
DCNG-977 Capture Jira+Confluence access logs into local-home volume

### DIFF
--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -176,6 +176,19 @@ The command that should be run by the nfs-fixer init container to correct the pe
 {{- end }}
 {{- end }}
 
+{{ define "confluence.volumeMounts" }}
+- name: local-home
+  mountPath: {{ .Values.volumes.localHome.mountPath | quote }}
+- name: local-home
+  mountPath: {{ .Values.confluence.accessLog.mountPath | quote }}
+  subPath: {{ .Values.confluence.accessLog.localHomeSubPath | quote }}
+- name: shared-home
+  mountPath: {{ .Values.volumes.sharedHome.mountPath | quote }}
+  {{- if .Values.volumes.sharedHome.subPath }}
+  subPath: {{ .Values.volumes.sharedHome.subPath | quote }}
+  {{- end }}
+{{ end }}
+
 {{/*
 For each additional library declared, generate a volume mount that injects that library into the Confluence lib directory
 */}}

--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -176,6 +176,11 @@ The command that should be run by the nfs-fixer init container to correct the pe
 {{- end }}
 {{- end }}
 
+{{/*
+Defines the volume mounts used by the Confluence container.
+Note that the local-home volume is mounted twice, once for the local-home directory itself, and again
+on Tomcat's logs directory. THis ensures that Tomcat+Confluence logs get captured in the same volume.
+*/}}
 {{ define "confluence.volumeMounts" }}
 - name: local-home
   mountPath: {{ .Values.volumes.localHome.mountPath | quote }}

--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -52,13 +52,7 @@ spec:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: local-home
-              mountPath: {{ .Values.volumes.localHome.mountPath | quote }}
-            - name: shared-home
-              mountPath: {{ .Values.volumes.sharedHome.mountPath | quote }}
-              {{- if .Values.volumes.sharedHome.subPath }}
-              subPath: {{ .Values.volumes.sharedHome.subPath | quote }}
-              {{- end }}
+            {{- include "confluence.volumeMounts" . | nindent 12 }}
             {{- with .Values.confluence.additionalVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -71,6 +65,8 @@ spec:
             - name: ATL_TOMCAT_SECURE
               value: "true"
             {{ end }}
+            - name: ATL_TOMCAT_ACCESS_LOG
+              value: {{ .Values.confluence.accessLog.enabled | quote }}
             - name: ATL_PRODUCT_HOME_SHARED
               value: {{ .Values.volumes.sharedHome.mountPath | quote }}
             - name: JVM_SUPPORT_RECOMMENDED_ARGS

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -79,7 +79,7 @@ confluence:
 
   accessLog:
     # -- True if access logging should be enabled.
-    enabled: false
+    enabled: true
     # -- The path within the Confluence container where the local-home volume should be mounted in order to capture access logs.
     mountPath: "/opt/atlassian/confluence/logs"
     # -- The subdirectory within the local-home volume where access logs should be stored.

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -77,6 +77,14 @@ confluence:
     # -- The number of consecutive failures of the Confluence container readiness probe before the pod fails readiness checks
     failureThreshold: 30
 
+  accessLog:
+    # -- True if access logging should be enabled.
+    enabled: false
+    # -- The path within the Confluence container where the local-home volume should be mounted in order to capture access logs.
+    mountPath: "/opt/atlassian/confluence/logs"
+    # -- The subdirectory within the local-home volume where access logs should be stored.
+    localHomeSubPath: "logs"
+
   clustering:
     # -- Set to true if Data Center clustering should be enabled
     # This will automatically configure cluster peer discovery between cluster nodes.
@@ -197,6 +205,7 @@ volumes:
     # -- When persistentVolumeClaim.create is false, then this value can be used to define a standard Kubernetes
     # volume which will be used for the local-home volumes. If not defined, then defaults to an emptyDir volume.
     customVolume: {}
+    # -- The path within the Confluence container which the local-home volume should be mounted.
     mountPath: "/var/atlassian/application-data/confluence"
   sharedHome:
     persistentVolumeClaim:

--- a/src/main/charts/jira/templates/_helpers.tpl
+++ b/src/main/charts/jira/templates/_helpers.tpl
@@ -93,6 +93,11 @@ The command that should be run by the nfs-fixer init container to correct the pe
 {{- end }}
 {{- end }}
 
+{{/*
+Defines the volume mounts used by the Jira container.
+Note that the local-home volume is mounted twice, once for the local-home directory itself, and again
+on Tomcat's logs directory. THis ensures that Tomcat+Jira logs get captured in the same volume.
+*/}}
 {{ define "jira.volumeMounts" }}
 - name: local-home
   mountPath: {{ .Values.volumes.localHome.mountPath | quote }}

--- a/src/main/charts/jira/templates/_helpers.tpl
+++ b/src/main/charts/jira/templates/_helpers.tpl
@@ -93,6 +93,19 @@ The command that should be run by the nfs-fixer init container to correct the pe
 {{- end }}
 {{- end }}
 
+{{ define "jira.volumeMounts" }}
+- name: local-home
+  mountPath: {{ .Values.volumes.localHome.mountPath | quote }}
+- name: local-home
+  mountPath: {{ .Values.jira.accessLog.mountPath | quote }}
+  subPath: {{ .Values.jira.accessLog.localHomeSubPath | quote }}
+- name: shared-home
+  mountPath: {{ .Values.volumes.sharedHome.mountPath | quote }}
+  {{- if .Values.volumes.sharedHome.subPath }}
+  subPath: {{ .Values.volumes.sharedHome.subPath | quote }}
+  {{- end }}
+{{- end }}
+
 {{/*
 For each additional library declared, generate a volume mount that injects that library into the Jira lib directory
 */}}

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -83,13 +83,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: local-home
-              mountPath: {{ .Values.volumes.localHome.mountPath | quote }}
-            - name: shared-home
-              mountPath: {{ .Values.volumes.sharedHome.mountPath | quote }}
-              {{- if .Values.volumes.sharedHome.subPath }}
-              subPath: {{ .Values.volumes.sharedHome.subPath | quote }}
-              {{- end }}
+            {{- include "jira.volumeMounts" . | nindent 12 }}
             {{- with .Values.jira.additionalVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -60,6 +60,12 @@ jira:
     # -- The number of consecutive failures of the Jira container readiness probe before the pod fails readiness checks
     failureThreshold: 30
 
+  accessLog:
+    # -- The path within the Jira container where the local-home volume should be mounted in order to capture access logs.
+    mountPath: "/opt/atlassian/jira/logs"
+    # -- The subdirectory within the local-home volume where access logs should be stored.
+    localHomeSubPath: "log"
+
   clustering:
     # -- Set to true if Data Center clustering should be enabled
     # This will automatically configure cluster peer discovery between cluster nodes.

--- a/src/test/config/confluence/values.yaml
+++ b/src/test/config/confluence/values.yaml
@@ -11,6 +11,8 @@ confluence:
     container:
       requests:
         memory: 2G
+  accessLog:
+    enabled: true
 
 database:
   type: postgresql

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -109,6 +109,9 @@ spec:
           volumeMounts:
             - name: local-home
               mountPath: "/var/atlassian/application-data/confluence"
+            - name: local-home
+              mountPath: "/opt/atlassian/confluence/logs"
+              subPath: "logs"
             - name: shared-home
               mountPath: "/var/atlassian/application-data/shared-home"
           env:
@@ -116,6 +119,8 @@ spec:
               value: "https"
             - name: ATL_TOMCAT_SECURE
               value: "true"
+            - name: ATL_TOMCAT_ACCESS_LOG
+              value: "false"
             - name: ATL_PRODUCT_HOME_SHARED
               value: "/var/atlassian/application-data/shared-home"
             - name: JVM_SUPPORT_RECOMMENDED_ARGS

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -120,7 +120,7 @@ spec:
             - name: ATL_TOMCAT_SECURE
               value: "true"
             - name: ATL_TOMCAT_ACCESS_LOG
-              value: "false"
+              value: "true"
             - name: ATL_PRODUCT_HOME_SHARED
               value: "/var/atlassian/application-data/shared-home"
             - name: JVM_SUPPORT_RECOMMENDED_ARGS

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -125,6 +125,9 @@ spec:
           volumeMounts:
             - name: local-home
               mountPath: "/var/atlassian/application-data/jira"
+            - name: local-home
+              mountPath: "/opt/atlassian/jira/logs"
+              subPath: "log"
             - name: shared-home
               mountPath: "/var/atlassian/application-data/shared-home"
       volumes:


### PR DESCRIPTION
Due to the way that the Jira+Confluence applications are constructed, with the application deployed as a WAR into Tomcat, the Tomcat logs (including the access logs) are stored in a different place in the filesystem to the application logs. 

Currently, the application logs are a sub-directory of the local-home volume, but the tomcat+access logs are just being stored on the container's internal filesystem.

This PR captures those tomcat+access logs into the local-home volume. It does this by double-mounting the local-home volume on to two separate paths in the container. The first mount point is the existing one (which captures the application logs due to them being in the `logs` sub-directory), but now I've added another mount point for the local-home volume, so that the Tomcat logs directory is also mounted on the logs subdirectory of local-home.

It's a bit peculiar to double-mount the same volume twice, but it's perfectly valid. The end result is that the same logs subdirectory of the local-home volume now contains both sets of logs, and the customer no longer has to worry about where to look for them. 