### PR TITLE
DCNG-976 use http source for Confluence fluentd events

### DIFF
--- a/src/main/charts/confluence/templates/_fluentd_templates.tpl
+++ b/src/main/charts/confluence/templates/_fluentd_templates.tpl
@@ -7,10 +7,6 @@
     - containerPort: {{ .Values.fluentd.httpPort }}
       protocol: TCP
   volumeMounts:
-    - name: local-home
-      mountPath: /application-data/logs
-      subPath: logs
-      readOnly: true
     - name: fluentd-config
       mountPath: /fluentd/etc
       readOnly: true

--- a/src/main/charts/confluence/templates/_fluentd_templates.tpl
+++ b/src/main/charts/confluence/templates/_fluentd_templates.tpl
@@ -3,6 +3,9 @@
 - name: fluentd
   image: {{ .Values.fluentd.imageName }}
   command: ["fluentd", "-c", "/fluentd/etc/fluent.conf", "-v"]
+  ports:
+    - containerPort: {{ .Values.fluentd.httpPort }}
+      protocol: TCP
   volumeMounts:
     - name: local-home
       mountPath: /application-data/logs

--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -145,6 +145,12 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 -Dconfluence.clusterNodeName.useHostname={{ .Values.confluence.clustering.usePodNameAsClusterNodeName }}
 {{- end }}
 
+{{- define "confluence.sysprop.fluentdAppender" -}}
+{{- if .Values.fluentd.enabled -}}
+-Datlassian.logging.cloud.enabled=true
+{{- end -}}
+{{- end }}
+
 {{- define "confluence.sysprop.synchronyServiceUrl" -}}
 {{- if .Values.synchrony.enabled -}}
 -Dsynchrony.service.url={{ .Values.synchrony.ingressUrl }}/v1

--- a/src/main/charts/confluence/templates/config-jvm.yaml
+++ b/src/main/charts/confluence/templates/config-jvm.yaml
@@ -9,6 +9,7 @@ data:
     {{ include "confluence.sysprop.hazelcastListenPort" . }}
     {{ include "confluence.sysprop.synchronyServiceUrl" . }}
     {{ include "confluence.sysprop.clusterNodeName" . }}
+    {{ include "confluence.sysprop.fluentdAppender" . }}
     {{- range .Values.confluence.additionalJvmArgs }}
     {{ . }}
     {{- end }}

--- a/src/main/charts/confluence/templates/configmap-fluentd.yaml
+++ b/src/main/charts/confluence/templates/configmap-fluentd.yaml
@@ -8,14 +8,9 @@ metadata:
 data:
   fluent.conf: |
     <source>
-      @type tail
-      path /application-data/logs/atlassian-confluence.log*
-      read_from_head true
-      tag confluence.log
-      <parse>
-        @type regexp
-        expression /^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}) (?<level>[A-Z]+) \[(?<thread>\S+)\] \[(?<logger>\S+)\] (?<method>[\w|\$]+) (?<message>.*)$/
-      </parse>
+      @type http
+      port {{ .Values.fluentd.httpPort }}
+      bind 0.0.0.0
     </source>
 
     <filter **>
@@ -32,9 +27,12 @@ data:
       @type stdout
     </filter>
 
+    {{ if .Values.fluentd.elasticsearch.enabled }}
     <match **>
       @type elasticsearch
       host {{ .Values.fluentd.elasticsearch.hostname }}
       logstash_format true
+      logstash_prefix {{ .Values.fluentd.elasticsearch.indexNamePrefix }}
     </match>
+    {{ end }}
 {{ end }}

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -199,9 +199,15 @@ fluentd:
   enabled: false
   # -- The name of the image containing the fluentd sidecar
   imageName: fluent/fluentd-kubernetes-daemonset:v1.11.5-debian-elasticsearch7-1.2
+  # -- The port on which the fluentd sidecar will listen
+  httpPort: 9880
   elasticsearch:
+    # -- True if fluentd should send all log events to an elasticsearch service.
+    enabled: true
     # -- The hostname of the Elasticsearch service that fluentd should send logs to.
-    hostname:
+    hostname: elasticsearch
+    # -- The prefix of the elasticsearch index name that will be used
+    indexNamePrefix: confluence
 
 # -- Specify additional annotations to be added to all Confluence and Synchrony pods
 podAnnotations: {}


### PR DESCRIPTION
When Confluence is configured to use the fluentd log appender, it will post log events directly to the fluentd sidecar, avoiding the need to use a complicated regex to parse the human-readable log file.