### PR TITLE
improvements to events fetching

### DIFF
--- a/src/test/scripts/download_logs.sh
+++ b/src/test/scripts/download_logs.sh
@@ -37,6 +37,10 @@ getPodLogs "$RELEASE_PREFIX-pgsql"
 
 getIngresses "$PRODUCT_RELEASE_NAME"
 
-kubectl get events -n "${TARGET_NAMESPACE}" --sort-by=.metadata.creationTimestamp > "$LOG_DOWNLOAD_DIR/events.txt"
+#this is the same format as kubectl get events, but with absolute timestamps instead of relative
+filter='.items[] | .firstTimestamp + ".." + .lastTimestamp + "\u0009" + .type + "\u0009" + .reason + "\u0009" + .involvedObject.kind + "/" + .involvedObject.name + "\u0009" + .message'
+
+kubectl get events -n "${TARGET_NAMESPACE}" --sort-by=.metadata.creationTimestamp  -o json | \
+  jq -r "$filter" > "$LOG_DOWNLOAD_DIR/events.txt"
 
 exit 0


### PR DESCRIPTION
Correlating the existing format with test failures is very hard. New format:
```
2021-01-17T21:47:29Z..2021-01-27T21:43:23Z	Warning	FailedScheduling	Pod/shared-home-browser         persistentvolumeclaim "efs-claim" not found
2021-01-27T13:08:18Z..2021-01-27T21:45:31Z	Normal	NotTriggerScaleUp	Pod/shared-home-browser         pod didn't trigger scale-up (it wouldn't fit if a new node is added):
2021-01-27T15:01:56Z..2021-01-27T21:44:56Z	Warning	Unhealthy	Pod/dcng-k8sjira-668-jira-0         Readiness probe failed: HTTP probe failed with statuscode: 503
2021-01-27T17:06:25Z..2021-01-27T21:39:42Z	Warning	FailedMount	Pod/dcng-k8shelmtest124-2-bitbucket-shared-home-permissions-test         Unable to attach or mount volumes: unmounted volumes=[shared-home], unattached volumes=[shared-home default-token-4xr6x]: error processing PVC dcng/dcng-k8shelmtest124-2-bitbucket-shared-home: PVC is being deleted
2021-01-27T17:07:46Z..2021-01-27T21:43:40Z	Warning	FailedKillPod	Pod/dcng-k8sbbs16-8-bitbucket-nfs-server         error killing pod: failed to "KillContainer" for "nfs-server-container" with KillContainerError: "rpc error: code = Unknown desc = operation timeout: context deadline exceeded"
2021-01-27T17:09:25Z..2021-01-27T21:44:44Z	Warning	FailedMount	Pod/dcng-k8sbbs-805-bitbucket-shared-home-permissions-test         Unable to attach or mount volumes: unmounted volumes=[shared-home], unattached volumes=[shared-home default-token-4xr6x]: error processing PVC dcng/dcng-k8sbbs-805-bitbucket-shared-home: PVC is being deleted
2021-01-27T17:10:19Z..2021-01-27T21:34:47Z	Warning	FailedMount	Pod/dcng-k8sbbs-805-bitbucket-shared-home-permissions-test         Unable to attach or mount volumes: unmounted volumes=[shared-home], unattached volumes=[default-token-4xr6x shared-home]: error processing PVC dcng/dcng-k8sbbs-805-bitbucket-shared-home: PVC is being deleted
2021-01-27T17:08:30Z..2021-01-27T21:44:39Z	Warning	FailedMount	Pod/dcng-k8shelmtest124-2-bitbucket-shared-home-permissions-test         Unable to attach or mount volumes: unmounted volumes=[shared-home], unattached volumes=[default-token-4xr6x shared-home]: error processing PVC dcng/dcng-k8shelmtest124-2-bitbucket-shared-home: PVC is being deleted
```