### PR TITLE
DCNG-976 Send jira logs to fluentd via http rather than log file tailing

### DIFF
--- a/src/main/charts/jira/templates/_fluentd_templates.tpl
+++ b/src/main/charts/jira/templates/_fluentd_templates.tpl
@@ -4,10 +4,6 @@
   image: {{ .Values.fluentd.imageName }}
   command: ["fluentd", "-c", "/fluentd/etc/fluent.conf", "-v"]
   volumeMounts:
-    - name: local-home
-      mountPath: /application-data/logs
-      subPath: log
-      readOnly: true
     - name: fluentd-config
       mountPath: /fluentd/etc
       readOnly: true

--- a/src/main/charts/jira/templates/_helpers.tpl
+++ b/src/main/charts/jira/templates/_helpers.tpl
@@ -234,3 +234,9 @@ volumeClaimTemplates:
       fieldPath: status.podIP
 {{ end }}
 {{ end }}
+
+{{- define "jira.sysprop.fluentdAppender" -}}
+{{- if .Values.fluentd.enabled -}}
+-Datlassian.logging.cloud.enabled=true
+{{- end -}}
+{{- end }}

--- a/src/main/charts/jira/templates/config-jvm.yaml
+++ b/src/main/charts/jira/templates/config-jvm.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "jira.labels" . | nindent 4 }}
 data:
   additional_jvm_args: >-
+    {{ include "jira.sysprop.fluentdAppender" . }}
     {{- range .Values.jira.additionalJvmArgs }}
     {{ . }}
     {{- end }}

--- a/src/main/charts/jira/templates/configmap-fluentd.yaml
+++ b/src/main/charts/jira/templates/configmap-fluentd.yaml
@@ -8,14 +8,9 @@ metadata:
 data:
   fluent.conf: |
     <source>
-      @type tail
-      path /application-data/logs/atlassian-jira.log*
-      read_from_head true
-      tag jira.log
-      <parse>
-        @type regexp
-        expression /^(?<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}[+|-]\d{4}) (?<message>.*)$/
-      </parse>
+      @type http
+      port {{ .Values.fluentd.httpPort }}
+      bind 0.0.0.0
     </source>
 
     <filter **>
@@ -32,9 +27,12 @@ data:
       @type stdout
     </filter>
 
+    {{ if .Values.fluentd.elasticsearch.enabled }}
     <match **>
       @type elasticsearch
       host {{ .Values.fluentd.elasticsearch.hostname }}
       logstash_format true
+      logstash_prefix {{ .Values.fluentd.elasticsearch.indexNamePrefix }}
     </match>
+    {{ end }}
 {{ end }}

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -155,9 +155,15 @@ fluentd:
   enabled: false
   # -- The name of the image containing the fluentd sidecar
   imageName: fluent/fluentd-kubernetes-daemonset:v1.11.5-debian-elasticsearch7-1.2
+  # -- The port on which the fluentd sidecar will listen
+  httpPort: 9880
   elasticsearch:
+    # -- True if fluentd should send all log events to an elasticsearch service.
+    enabled: true
     # -- The hostname of the Elasticsearch service that fluentd should send logs to.
-    hostname:
+    hostname: elasticsearch
+    # -- The prefix of the elasticsearch index name that will be used
+    indexNamePrefix: jira
 
 # -- Specify custom annotations to be added to all Jira pods
 podAnnotations: {}


### PR DESCRIPTION
Jira master now has the HTTP fluentd log4j appender configured, so now we need to change the Helm chart to activate the appropriate system property, and to replace the log tailing logic in fluent with the HTTP listener.

This has been done for Confluence already.