### PR TITLE
Dump current status of all relevant kube resources for diagnostics

### DIFF
--- a/src/test/scripts/download_logs.sh
+++ b/src/test/scripts/download_logs.sh
@@ -5,6 +5,8 @@ source $1
 RELEASE_PREFIX=$(echo "${RELEASE_PREFIX}" | tr '[:upper:]' '[:lower:]')
 PRODUCT_RELEASE_NAME=$RELEASE_PREFIX-$PRODUCT_NAME
 
+THISDIR=$(dirname "$0")
+
 mkdir -p "$LOG_DOWNLOAD_DIR"
 
 getPodLogs() {
@@ -36,10 +38,12 @@ getIngresses() {
 getResourcesStatus() {
     local releaseName=$1
 
-    echo "Showing status of all Kube resources in namespace ${TARGET_NAMESPACE} for Helm release $releaseName"
+    echo "Status of all pods in namespace ${TARGET_NAMESPACE} for Helm release $releaseName"
+    kubectl get pod -o custom-columns-file="$THISDIR/pod_status_custom_columns.txt" -l "app.kubernetes.io/instance=$releaseName" -n "${TARGET_NAMESPACE}"
+
+    echo "Status of all other Kube resources in namespace ${TARGET_NAMESPACE} for Helm release $releaseName"
 
     for type in pod statefulset service pvc serviceaccount configmap clusterrole clusterrolebinding node; do
-      echo "Status of all $type resources"
       kubectl get $type -o wide --show-kind --ignore-not-found -l "app.kubernetes.io/instance=$releaseName" -n "${TARGET_NAMESPACE}"
     done
 }

--- a/src/test/scripts/download_logs.sh
+++ b/src/test/scripts/download_logs.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -x
-
 source $1
 
 RELEASE_PREFIX=$(echo "${RELEASE_PREFIX}" | tr '[:upper:]' '[:lower:]')
@@ -34,6 +32,20 @@ getIngresses() {
       kubectl -n "${TARGET_NAMESPACE}" describe ingress "$ingressName" > "$LOG_DOWNLOAD_DIR/ingress-$ingressName.yaml"
     done
 }
+
+getResourcesStatus() {
+    local releaseName=$1
+
+    echo "Showing status of all Kube resources in namespace ${TARGET_NAMESPACE} for Helm release $releaseName"
+
+    for type in pod statefulset service pvc serviceaccount configmap clusterrole clusterrolebinding node; do
+      echo "Status of all $type resources"
+      kubectl get $type -o wide --show-kind --ignore-not-found -l "app.kubernetes.io/instance=$releaseName" -n "${TARGET_NAMESPACE}"
+    done
+}
+
+getResourcesStatus "$PRODUCT_RELEASE_NAME"
+getResourcesStatus "$PRODUCT_RELEASE_NAME-pgsql"
 
 getPodLogs "$PRODUCT_RELEASE_NAME"
 getPodLogs "$RELEASE_PREFIX-pgsql"

--- a/src/test/scripts/download_logs.sh
+++ b/src/test/scripts/download_logs.sh
@@ -43,7 +43,7 @@ getResourcesStatus() {
 
     echo "Status of all other Kube resources in namespace ${TARGET_NAMESPACE} for Helm release $releaseName"
 
-    for type in pod statefulset service pvc serviceaccount configmap clusterrole clusterrolebinding node; do
+    for type in statefulset service pvc serviceaccount configmap clusterrole clusterrolebinding node; do
       kubectl get $type -o wide --show-kind --ignore-not-found -l "app.kubernetes.io/instance=$releaseName" -n "${TARGET_NAMESPACE}"
     done
 }

--- a/src/test/scripts/pod_status_custom_columns.txt
+++ b/src/test/scripts/pod_status_custom_columns.txt
@@ -1,0 +1,2 @@
+POD             IP              STATUS          CONTAINERS              READY                               IMAGES
+metadata.name   status.podIP    status.phase    spec.containers[*].name status.containerStatuses[*].ready   spec.containers[*].image


### PR DESCRIPTION
Add some extra diagnostics to `download_logs.sh`, so that we display the summary status of every resource in the Helm release.