### PR TITLE
DCNG-1045 try to log node metrics also

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons-io.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <version>3.0.2</version>
@@ -86,6 +92,7 @@
         <jackson.version>2.12.1</jackson.version>
         <kubernetes-client.version>5.0.1</kubernetes-client.version>
         <slf4j.version>1.7.30</slf4j.version>
+        <commons-io.version>2.8.0</commons-io.version>
 
         <dockerImage.registry />
         <dockerImage.version />

--- a/src/test/java/test/postinstall/KubeClient.java
+++ b/src/test/java/test/postinstall/KubeClient.java
@@ -1,0 +1,78 @@
+package test.postinstall;
+
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetrics;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.vavr.Lazy;
+import io.vavr.Tuple;
+import io.vavr.collection.Array;
+import io.vavr.collection.Traversable;
+import io.vavr.control.Option;
+import io.vavr.control.Try;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+final class KubeClient implements AutoCloseable {
+    private static final Logger log = LoggerFactory.getLogger(KubeClient.class);
+
+    private final Lazy<KubernetesClient> clientRef = Lazy.of(DefaultKubernetesClient::new);
+
+    io.vavr.collection.Map<Node, Option<NodeMetrics>> getNodeMetrics(final PodSpec podSpec) {
+        return getNodes(podSpec.getNodeSelector())
+                .toMap(node -> Tuple.of(node, getNodeMetrics(node)));
+    }
+
+    private Option<NodeMetrics> getNodeMetrics(Node node) {
+        return Try.of(() -> client().top().nodes().metrics(node.getMetadata().getName()))
+                .onFailure(ex -> log.warn("Failed to call K8S Ketrics API: {}", ex.getMessage()))
+                .toOption();
+    }
+
+    /**
+     * @return all k8s custer nodes which are available for pod scheduling, based on the node selector in the
+     * StatefulSet spec.
+     */
+    private Traversable<Node> getNodes(final Map<String, String> nodeSelector) {
+        return Array.ofAll(client()
+                .nodes()
+                .withLabels(nodeSelector)
+                .list()
+                .getItems());
+    }
+
+    @Nullable
+    StatefulSet getStatefulSet(String statefulSetName, final String namespaceName) {
+        return client()
+                .apps().statefulSets()
+                .inNamespace(namespaceName)
+                .withName(statefulSetName)
+                .get();
+    }
+
+    @Nullable
+    Pod getPod(final String podName, final String namespaceName) {
+        return client()
+                .pods()
+                .inNamespace(namespaceName)
+                .withName(podName)
+                .get();
+    }
+
+    private KubernetesClient client() {
+        return clientRef.get();
+    }
+
+    @Override
+    public void close() {
+        if (clientRef.isEvaluated()) {
+            clientRef.forEach(KubernetesClient::close);
+        }
+    }
+}

--- a/src/test/java/test/postinstall/PostInstallStatusTest.java
+++ b/src/test/java/test/postinstall/PostInstallStatusTest.java
@@ -1,42 +1,76 @@
 package test.postinstall;
 
 import io.fabric8.kubernetes.api.model.ContainerStatus;
+import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.vavr.Lazy;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetrics;
 import io.vavr.collection.Array;
+import io.vavr.collection.Map;
+import io.vavr.control.Option;
+import org.assertj.core.description.Description;
+import org.assertj.core.description.LazyTextDescription;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nullable;
 import java.nio.file.Path;
-import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static test.postinstall.Utils.netNodesResourceSummary;
 
 class PostInstallStatusTest {
     private static String helmReleaseName;
     private static String namespaceName;
 
-    private static final Lazy<KubernetesClient> clientRef = Lazy.of(DefaultKubernetesClient::new);
+    private static final KubeClient client = new KubeClient();
 
     @Test
     void applicationPodsShouldAllBeRunning() {
-        forEachPodOfStatefulSet((idx, pod) ->
-                assertThat(pod.getStatus().getPhase())
-                        .describedAs("Pod %s should be running", pod.getMetadata().getName())
-                        .isEqualToIgnoringCase("running"));
+        forEachPodOfStatefulSet(pod -> {
+            final var podPhase = pod.getStatus().getPhase();
+
+            // First assert that the phase is not "pending", and if so we show a special failure message
+            assertThat(podPhase)
+                    .describedAs(schedulingFailure(pod))
+                    .isNotEqualToIgnoringCase("pending");
+
+            // otherwise assert that the pod is running
+            assertThat(podPhase)
+                    .describedAs("Pod %s should be running", pod.getMetadata().getName())
+                    .isEqualToIgnoringCase("Running");
+        });
+    }
+
+    private Description schedulingFailure(Pod pod) {
+        return new LazyTextDescription(() -> {
+            final var podSpec = getStatefulSet()
+                    .getSpec()
+                    .getTemplate()
+                    .getSpec();
+            return schedulingFailure(pod.getMetadata().getName(), client.getNodeMetrics(podSpec));
+        });
+    }
+
+    private String schedulingFailure(final String podName, Map<Node, Option<NodeMetrics>> nodeMetrics) {
+        final var resourceSummary = netNodesResourceSummary(nodeMetrics);
+
+        return String.format("Pod %s should be running, but has yet to be scheduled on the cluster. Current node usage is %s",
+                podName, resourceSummary);
     }
 
     @Test
     void applicationPodContainersShouldAllBeReady() {
-        forEachPodOfStatefulSet((idx, pod) -> {
+        forEachPodOfStatefulSet(pod -> {
             final var containerStatuses = Array.ofAll(pod.getStatus().getContainerStatuses());
-            final var containerNames = containerStatuses.map(ContainerStatus::getName).mkCharSeq(",");
+
+            assumeThat(containerStatuses)
+                    .describedAs("No container statuses present in pod %s", pod.getMetadata().getName())
+                    .isNotEmpty();
+
+            final var containerNames = containerStatuses.map(ContainerStatus::getName).mkCharSeq("[", ",", "]");
 
             assertThat(containerStatuses)
                     .extracting(ContainerStatus::getReady)
@@ -45,50 +79,24 @@ class PostInstallStatusTest {
         });
     }
 
-    @Test
-    void allPersistentVolumeClaimsShouldBeBound() {
-        final var volumeClaims = clientRef.get().persistentVolumeClaims()
-                .withLabel("app.kubernetes.io/instance", helmReleaseName)
-                .list()
-                .getItems();
-
-        for (var volumeClaim : volumeClaims) {
-            assertThat(volumeClaim.getStatus().getPhase())
-                    .isEqualToIgnoringCase("bound");
-        }
-    }
-
-    private void forEachPodOfStatefulSet(BiConsumer<Integer, Pod> consumer) {
-        final var statefulSetName = helmReleaseName;
-        final var statefulSet = getStatefulSet(statefulSetName);
-
-        assertThat(statefulSet)
-                .describedAs("StatefulSet %s not found", statefulSetName)
-                .isNotNull();
+    private void forEachPodOfStatefulSet(Consumer<Pod> consumer) {
+        final var statefulSet = getStatefulSet();
 
         final var replicaCount = statefulSet.getStatus().getReplicas();
 
         for (var idx = 0; idx < replicaCount; idx++) {
-            consumer.accept(idx, getPod(statefulSetName + "-" + idx));
+            consumer.accept(client.getPod(statefulSet.getMetadata().getName() + "-" + idx, namespaceName));
         }
     }
 
-    @Nullable
-    private StatefulSet getStatefulSet(String statefulSetName) {
-        return clientRef.get()
-                .apps().statefulSets()
-                .inNamespace(namespaceName)
-                .withName(statefulSetName)
-                .get();
-    }
+    StatefulSet getStatefulSet() {
+        final var statefulSetName = helmReleaseName;
+        final var statefulSet = client.getStatefulSet(statefulSetName, namespaceName);
 
-    @Nullable
-    private Pod getPod(final String podName) {
-        return clientRef.get()
-                .pods()
-                .inNamespace(namespaceName)
-                .withName(podName)
-                .get();
+        assertThat(statefulSet)
+                .describedAs("StatefulSet %s not found", statefulSetName)
+                .isNotNull();
+        return statefulSet;
     }
 
     @BeforeAll
@@ -119,6 +127,6 @@ class PostInstallStatusTest {
 
     @AfterAll
     static void disposeOfClient() {
-        clientRef.forEach(KubernetesClient::close);
+        client.close();
     }
 }

--- a/src/test/java/test/postinstall/Utils.java
+++ b/src/test/java/test/postinstall/Utils.java
@@ -1,21 +1,63 @@
 package test.postinstall;
 
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.metrics.v1beta1.NodeMetrics;
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
+import io.vavr.collection.Array;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.Map;
+import io.vavr.control.Option;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
+
+import static io.fabric8.kubernetes.api.model.Quantity.getAmountInBytes;
+import static java.nio.file.Files.newBufferedReader;
+import static org.apache.commons.io.FileUtils.byteCountToDisplaySize;
 
 final class Utils {
     static Map<String, String> readPropertiesFile(final Path fileLocation) throws IOException {
         final var properties = new Properties();
-        try (var reader = Files.newBufferedReader(fileLocation)) {
+        try (var reader = newBufferedReader(fileLocation)) {
             properties.load(reader);
         }
         return HashMap.ofAll(properties)
                 .mapKeys(String.class::cast)
                 .mapValues(String.class::cast);
+    }
+
+    static String getQuantitiesDescription(final java.util.Map<String, Quantity> allocatable) {
+        return Array.empty()
+                .appendAll(HashMap.ofAll(allocatable)
+                        .get("memory")
+                        .map(Utils::getDataSize)
+                        .map(dataSize -> String.format("memory=%s", dataSize)))
+                .appendAll(HashMap.ofAll(allocatable)
+                        .get("cpu")
+                        .map(quantity -> String.format("cpu=%s", quantity)))
+                .mkString(", ");
+    }
+
+    private static String getDataSize(Quantity quantity) {
+        return byteCountToDisplaySize(getAmountInBytes(quantity).toBigInteger());
+    }
+
+    static String netNodesResourceSummary(final Map<Node, Option<NodeMetrics>> nodes) {
+        return nodes.map(Utils::getNodeResourceSummary)
+                .toJavaMap()
+                .toString();
+    }
+
+    private static Tuple2<String, String> getNodeResourceSummary(Node node, Option<NodeMetrics> metrics) {
+        final var allocatableDescription = getQuantitiesDescription(node.getStatus().getAllocatable());
+        final var usageDescription = metrics.map(m -> getQuantitiesDescription(m.getUsage()))
+                .getOrElse("metrics unavailable");
+
+        final var description = String.format("usage=[%s], capacity=[%s]", usageDescription, allocatableDescription);
+
+        return Tuple.of(node.getMetadata().getName(), description);
     }
 }


### PR DESCRIPTION
Another tweak to the `PostInstallSetupTest`, so that when a pod has yet to be scheduled, it logs a dedicated message to that effect, along with the CPU and memory capacity of the nodes that the pod is capable of being scheduled on. It also tries to log the actual cpu/memory usage of those nodes, but that requires the K8S Metrics API server to be enabled/installed, which it currently isn't.