### PR TITLE
feat(confluence): managed synchrony option

### DIFF
--- a/src/main/charts/confluence/Chart.yaml
+++ b/src/main/charts/confluence/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: confluence
 description: A chart for installing Confluence DC on Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 7.9.0-jdk11
 kubeVersion: ">=1.17.x-0"
 keywords:

--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -150,8 +150,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{- define "confluence.sysprop.synchronyServiceUrl" -}}
-{{- if .Values.synchrony.enabled -}}
+{{- if and .Values.synchrony.enabled (not .Values.synchrony.managed) -}}
 -Dsynchrony.service.url={{ .Values.synchrony.ingressUrl }}/v1
+{{- else if and .Values.synchrony.enabled .Values.synchrony.managed -}}
+-Dsynchrony.btf.disabled=false
 {{- else -}}
 -Dsynchrony.btf.disabled=true
 {{- end -}}

--- a/src/main/charts/confluence/templates/service-synchrony.yaml
+++ b/src/main/charts/confluence/templates/service-synchrony.yaml
@@ -11,11 +11,11 @@ spec:
     - port: {{ .Values.synchrony.service.port }}
       targetPort: http
       protocol: TCP
-      name: http
+      name: http-synch
     - port: {{ .Values.synchrony.ports.hazelcast }}
       targetPort: hazelcast
       protocol: TCP
-      name: hazelcast
+      name: hazelcast-synch
   selector:
     {{- include "synchrony.selectorLabels" . | nindent 4 }}
 {{ end }}

--- a/src/main/charts/confluence/templates/statefulset-synchrony.yaml
+++ b/src/main/charts/confluence/templates/statefulset-synchrony.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.synchrony.enabled }}
+{{ if and .Values.synchrony.enabled (not .Values.synchrony.managed) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -31,10 +31,10 @@ spec:
             - mountPath: /scripts
               name: entrypoint-script
           ports:
-            - name: http
+            - name: http-synch
               containerPort: {{ .Values.synchrony.ports.http }}
               protocol: TCP
-            - name: hazelcast
+            - name: hazelcast-synch
               containerPort: {{ .Values.synchrony.ports.hazelcast }}
               protocol: TCP
           readinessProbe:

--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "confluence.fullname" . }}
   labels:
     {{- include "confluence.labels" . | nindent 4 }}
+    {{- if and .Values.synchrony.enabled .Values.synchrony.managed }}
+    {{- include "synchrony.selectorLabels" . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   serviceName: {{ include "confluence.fullname" . }}
@@ -42,6 +45,14 @@ spec:
             - name: hazelcast
               containerPort: {{ .Values.confluence.ports.hazelcast }}
               protocol: TCP
+            {{- if and .Values.synchrony.enabled .Values.synchrony.managed }}
+            - name: http-synch
+              containerPort: {{ .Values.synchrony.ports.http }}
+              protocol: TCP
+            - name: hazelcast-synch
+              containerPort: {{ .Values.synchrony.ports.hazelcast }}
+              protocol: TCP
+            {{- end }}
           readinessProbe:
             httpGet:
               port: {{ .Values.confluence.ports.http }}

--- a/src/main/charts/confluence/templates/synchrony-start-script.yaml
+++ b/src/main/charts/confluence/templates/synchrony-start-script.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.synchrony.enabled }}
+{{ if and .Values.synchrony.enabled (not .Values.synchrony.managed) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -154,6 +154,9 @@ synchrony:
   # This will result in a separate StatefulSet and Service to be created for Synchrony.
   # If disabled, then Collaborative Editing will be disabled in Confluence.
   enabled: false
+  # -- True if Confluence should manage Synchrony rather than create a standalone cluster.
+  # See https://confluence.atlassian.com/doc/possible-confluence-and-synchrony-configurations-958779064.html
+  managed: false
   service:
     # -- The port on which the Synchrony Kubernetes service will listen
     port: 80


### PR DESCRIPTION
Feature for Confluence Helm chart that adds the ability to deploy Synchrony using a Confluence-managed configuration.  See https://confluence.atlassian.com/doc/possible-confluence-and-synchrony-configurations-958779064.html for details this configuration.

Changes included:
- Added `synchrony.managed` boolean to tell the Helm chart whether Synchrony should be deployed as a managed configuration or as a stand-alone cluster.  This is ignored if `synchrony.enabled` is `false`.
- If `synchrony.managed` is `true` and `synchrony.enabled` is `true`, the following are deployed:
   - JVM Option for `-Dsynchrony.btf.disabled=false`
   - Synchrony service (same as the stand-alone configuration).
   - Confluence statefulset with the following changes:
      - Synchrony `http` and `hazelcast` ports exposed.  The port names had to be renamed in order to avoid a conflict with Confluence's `http` and `hazelcast` ports
      - Additional Synchrony selector labels for Synchrony service
- Readme update using `helm-docs`
- Chart version bump

Testing notes: I manually tested Confluence in stand-alone mode only and verified `synchrony.enabled: false`, `synchrony.enabled: true` + `synchrony.managed: false`, and `synchrony.enabled: true` + `synchrony:managed: true`.  With Synchrony enabled, I tested with 2 users simultaneously editing a page.  I was using a PostgreSQL v10 database on the backend.