### PR TITLE
DCKUBE-103: add a system to enable collab editing by default

### DIFF
--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -149,6 +149,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 -Datlassian.logging.cloud.enabled={{.Values.fluentd.enabled}}
 {{- end }}
 
+{{- define "confluence.sysprop.enable.synchrony.by.default" -}}
+-Dsynchrony.by.default.enable.collab.editing.if.manually.managed=true
+{{- end -}}
+
 {{- define "confluence.sysprop.synchronyServiceUrl" -}}
 {{- if .Values.synchrony.enabled -}}
 -Dsynchrony.service.url={{ .Values.synchrony.ingressUrl }}/v1

--- a/src/main/charts/confluence/templates/config-jvm.yaml
+++ b/src/main/charts/confluence/templates/config-jvm.yaml
@@ -8,6 +8,7 @@ data:
   additional_jvm_args: >-
     {{ include "confluence.sysprop.hazelcastListenPort" . }}
     {{ include "confluence.sysprop.synchronyServiceUrl" . }}
+    {{ include "confluence.sysprop.enable.synchrony.by.default" . }}
     {{ include "confluence.sysprop.clusterNodeName" . }}
     {{ include "confluence.sysprop.fluentdAppender" . }}
     {{- range .Values.confluence.additionalJvmArgs }}

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -26,6 +26,7 @@ data:
   additional_jvm_args: >-
     -Dconfluence.cluster.hazelcast.listenPort=5701
     -Dsynchrony.btf.disabled=true
+    -Dsynchrony.by.default.enable.collab.editing.if.manually.managed=true
     -Dconfluence.clusterNodeName.useHostname=true
     -Datlassian.logging.cloud.enabled=false
   max_heap: 1g


### PR DESCRIPTION
This system property instructs Confluence to enable collab editing on fresh install if Synchrony is deployed in separate cluster. This property has been introduced in master branch of Confluence and so far it's used only by helm charts.