### PR TITLE
ISSUE-85: Add context path for Confluence

### DIFF
--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -45,7 +45,7 @@ spec:
           readinessProbe:
             httpGet:
               port: {{ .Values.confluence.ports.http }}
-              path: /status
+              path: {{ .Values.confluence.service.contextPath }}/status
             initialDelaySeconds: {{ .Values.confluence.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.confluence.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.confluence.readinessProbe.failureThreshold }}
@@ -66,6 +66,10 @@ spec:
               value: "https"
             - name: ATL_TOMCAT_SECURE
               value: "true"
+            {{ end }}
+            {{ if .Values.confluence.service.contextPath }}
+            - name: ATL_TOMCAT_CONTEXTPATH
+              value: {{ .Values.confluence.service.contextPath | quote }}
             {{ end }}
             - name: ATL_TOMCAT_ACCESS_LOG
               value: {{ .Values.confluence.accessLog.enabled | quote }}

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -55,6 +55,8 @@ confluence:
     port: 80
     # -- The type of Kubernetes service to use for Confluence
     type: ClusterIP
+    # -- The Tomcat context path that Confluence will use. The ATL_TOMCAT_CONTEXTPATH will be set automatically
+    contextPath:
   # -- Enable or disable security context in StatefulSet template spec. Enabled by default with UID 2002.
   # -- Disable when deploying to OpenShift, unless anyuid policy is attached to a service account
   securityContext:

--- a/src/test/java/test/ContextPathTest.java
+++ b/src/test/java/test/ContextPathTest.java
@@ -1,0 +1,43 @@
+package test;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import test.helm.Helm;
+import test.model.Product;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static test.jackson.JsonNodeAssert.assertThat;
+
+/**
+ * Tests the various permutations of the "<product>.license" value structure in the Helm charts
+ */
+class ContextPathTest {
+    private Helm helm;
+
+    @BeforeEach
+    void initHelm(TestInfo testInfo) {
+        helm = new Helm(testInfo);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = "confluence")
+    void confluence_context_path(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                "confluence.service.contextPath", "/confluence"));
+
+        resources.getStatefulSet(product.getHelmReleaseName())
+                .getContainer()
+                .getEnv()
+                .assertHasValue("ATL_TOMCAT_CONTEXTPATH", "/confluence");
+
+
+        assertEquals(resources.getStatefulSet(
+                product.getHelmReleaseName()).getContainer().get("readinessProbe").get("httpGet").get("path").asText(),
+                "/confluence/status");
+    }
+}


### PR DESCRIPTION
- add configuration for context path for Confluence service
- add context path to readinessProbe
- add test

Same feature as https://github.com/atlassian-labs/data-center-helm-charts/pull/86 for Confluence.