### PR TITLE
Issue/dckube 204 add helm debug option to builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
 
         <extra.parameters />
 
-        <helm.debug>false</helm.debug>
+        <helm.debug>true</helm.debug>
 
         <!-- The directory in which the helm (un)install script should look for the chart values files for integration testing -->
         <chart.testValues.basedir>${project.build.directory}/config</chart.testValues.basedir>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,8 @@
 
         <extra.parameters />
 
+        <helm.debug>false</helm.debug>
+
         <!-- The directory in which the helm (un)install script should look for the chart values files for integration testing -->
         <chart.testValues.basedir>${project.build.directory}/config</chart.testValues.basedir>
     </properties>

--- a/src/test/config/bitbucket/helm_parameters
+++ b/src/test/config/bitbucket/helm_parameters
@@ -20,3 +20,4 @@ INGRESS_DOMAIN_KITT=${kitt.ingress.domain}
 TARGET_REPLICA_COUNT=2
 DB_INIT_SCRIPT_FILE=${db.init.script.file}
 EXTRA_PARAMETERS="${extra.parameters}"
+HELM_DEBUG=${helm.debug}

--- a/src/test/config/confluence/helm_parameters
+++ b/src/test/config/confluence/helm_parameters
@@ -16,3 +16,4 @@ INGRESS_DOMAIN_KITT=${kitt.ingress.domain}
 # .Values.replicaCount=1, but in here we specify how many nodes we are planning to get to prepare ingress rules for each
 TARGET_REPLICA_COUNT=2
 DB_INIT_SCRIPT_FILE=${db.init.script.file}
+HELM_DEBUG=${helm.debug}

--- a/src/test/config/jira/helm_parameters
+++ b/src/test/config/jira/helm_parameters
@@ -16,3 +16,4 @@ INGRESS_DOMAIN_KITT=${kitt.ingress.domain}
 # .Values.replicaCount=1, but in here we specify how many nodes we are planning to get to prepare ingress rules for each
 TARGET_REPLICA_COUNT=2
 DB_INIT_SCRIPT_FILE=${db.init.script.file}
+HELM_DEBUG=${helm.debug}

--- a/src/test/scripts/helm_install.sh
+++ b/src/test/scripts/helm_install.sh
@@ -48,6 +48,7 @@ PRODUCT_RELEASE_NAME="$RELEASE_PREFIX-$PRODUCT_NAME"
 POSTGRES_RELEASE_NAME="$PRODUCT_RELEASE_NAME-pgsql"
 FUNCTEST_RELEASE_NAME="$PRODUCT_RELEASE_NAME-functest"
 HELM_PACKAGE_DIR=target/helm
+[ $HELM_DEBUG = "true" ] && HELM_DEBUG_OPTION="--debug"
 
 currentContext=$(kubectl config current-context)
 
@@ -102,6 +103,7 @@ helm install -n "${TARGET_NAMESPACE}" --wait \
    --set postgresqlUsername="$PRODUCT_NAME" \
    --set postgresqlPassword="$PRODUCT_NAME" \
    --version "$POSTGRES_CHART_VERSION" \
+   "$HELM_DEBUG_OPTION" \
    bitnami/postgresql > $LOG_DOWNLOAD_DIR/helm_install_log.txt
 
 if [[ "$DB_INIT_SCRIPT_FILE" ]]; then
@@ -135,6 +137,7 @@ helm package "$CHART_SRC_PATH" \
 # Install the product's Helm chart
 helm install -n "${TARGET_NAMESPACE}" --wait \
    "$PRODUCT_RELEASE_NAME" \
+   "$HELM_DEBUG_OPTION" \
    ${valueOverrides} \
    "$HELM_PACKAGE_DIR/${PRODUCT_NAME}"-*.tgz >> $LOG_DOWNLOAD_DIR/helm_install_log.txt
 
@@ -172,6 +175,7 @@ helm install --wait \
    "$FUNCTEST_RELEASE_NAME" \
    --set "$FUNCTEST_CHART_VALUES" \
    --values ${EXPOSE_NODES_FILE} \
+   "$HELM_DEBUG_OPTION" \
    "$HELM_PACKAGE_DIR/functest-0.1.0.tgz"
 
 # wait until the Ingress we just created starts serving up non-error responses - there may be a lag
@@ -195,5 +199,7 @@ do
 done
 
 # Run the chart's tests
-helm test "$PRODUCT_RELEASE_NAME" -n "${TARGET_NAMESPACE}"
+helm test \
+  "$HELM_DEBUG_OPTION" \
+  "$PRODUCT_RELEASE_NAME" -n "${TARGET_NAMESPACE}"
 


### PR DESCRIPTION
This will provide `--debug` flag to `helm install`. If provisioning fails, the logs will indicate why exactly it has failed.