### PR TITLE
indenting jira's additionalFiles volume mounts and adding to confluence

### DIFF
--- a/src/main/charts/confluence/templates/statefulset.yaml
+++ b/src/main/charts/confluence/templates/statefulset.yaml
@@ -147,6 +147,14 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        {{- range $i, $n := .Values.additionalFiles }}
+        - name: {{ .name }}-{{$i}}
+          {{ .type }}:
+            {{ if hasPrefix .type "secret" }}{{ .type}}Name{{ else }}name{{ end }}: {{ .name }}
+            items:
+              - key: {{ .key }}
+                path: {{ .key }}
+        {{ end }}
         {{ include "confluence.volumes" . | nindent 8 }}
         {{ include "fluentd.config.volume" . | nindent 8 }}
   {{ include "confluence.volumeClaimTemplates" . | nindent 2 }}

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -147,10 +147,10 @@ spec:
         {{- range $i, $n := .Values.additionalFiles }}
         - name: {{ .name }}-{{$i}}
           {{ .type }}:
-          {{ if hasPrefix .type "secret" }}{{ .type}}Name{{ else }}name{{ end }}: {{ .name }}
-          items:
-            - key: {{ .key }}
-              path: {{ .key }}
+            {{ if hasPrefix .type "secret" }}{{ .type}}Name{{ else }}name{{ end }}: {{ .name }}
+            items:
+              - key: {{ .key }}
+                path: {{ .key }}
         {{ end }}
         {{ include "jira.volumes" . | nindent 8 }}
         {{ include "fluentd.config.volume" . | nindent 8 }}

--- a/src/test/java/test/AdditionalFilesTest.java
+++ b/src/test/java/test/AdditionalFilesTest.java
@@ -1,0 +1,90 @@
+package test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import test.helm.Helm;
+import test.model.Product;
+import test.model.StatefulSet;
+
+import java.util.Map;
+
+import static test.jackson.JsonNodeAssert.assertThat;
+
+/**
+ * Tests the various permutations of the "<product>.service" value structure in the Helm charts
+ */
+class AdditionalFilesTest {
+    private Helm helm;
+
+    @BeforeEach
+    void initHelm(TestInfo testInfo) {
+        helm = new Helm(testInfo);
+    }
+
+    @ParameterizedTest
+    @EnumSource(Product.class)
+    void additional_files_config_map_creates_volumes(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                "additionalFiles[0].name", "custom-config-test",
+                "additionalFiles[0].type", "configMap",
+                "additionalFiles[0].key", "log4j.properties",
+                "additionalFiles[0].mountPath", "/var/atlassian"
+        ));
+
+        StatefulSet statefulSet = resources.getStatefulSet(product.getHelmReleaseName());
+        JsonNode configMap = getVolume(statefulSet, "configMap");
+
+        assertThat(configMap.path("name")).hasTextEqualTo("custom-config-test");
+        assertThat(configMap.path("items").path(0).path("key")).hasTextEqualTo("log4j.properties");
+        assertThat(configMap.path("items").path(0).path("path")).hasTextEqualTo("log4j.properties");
+    }
+
+
+    @ParameterizedTest
+    @EnumSource(Product.class)
+    void additional_files_secret_creates_new_secrets(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                "additionalFiles[0].name", "custom-config-test",
+                "additionalFiles[0].type", "secret",
+                "additionalFiles[0].key", "secretKey",
+                "additionalFiles[0].mountPath", "/var/secret"
+        ));
+
+        StatefulSet statefulSet = resources.getStatefulSet(product.getHelmReleaseName());
+        JsonNode configMap = getVolume(statefulSet, "secret");
+
+        assertThat(configMap.path("secretName")).hasTextEqualTo("custom-config-test");
+        assertThat(configMap.path("items").path(0).path("key")).hasTextEqualTo("secretKey");
+        assertThat(configMap.path("items").path(0).path("path")).hasTextEqualTo("secretKey");
+    }
+
+    @ParameterizedTest
+    @EnumSource(Product.class)
+    void additional_files_configMap_create_volume_mounts(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                "additionalFiles[0].name", "custom-config-test",
+                "additionalFiles[0].type", "secret",
+                "additionalFiles[0].key", "secretKey",
+                "additionalFiles[0].mountPath", "/var/secret"
+        ));
+
+        String name = "custom-config-test-0";
+
+        StatefulSet statefulSet = resources.getStatefulSet(product.getHelmReleaseName());
+        JsonNode volumeMount = statefulSet.getContainer(product.name()).getVolumeMount(name);
+
+        assertThat(volumeMount.path("name")).hasTextEqualTo("custom-config-test-0");
+        assertThat(volumeMount.path("mountPath")).hasTextEqualTo("/var/secret/secretKey");
+        assertThat(volumeMount.path("subPath")).hasTextEqualTo("secretKey");
+    }
+
+    private JsonNode getVolume(StatefulSet statefulSet, String secret) {
+        return statefulSet
+                .getVolume("custom-config-test-0")
+                .getOrElseThrow(() -> new AssertionError("custom config map is missing"))
+                .path(secret);
+    }
+}

--- a/src/test/java/test/model/Container.java
+++ b/src/test/java/test/model/Container.java
@@ -1,6 +1,7 @@
 package test.model;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.vavr.collection.Array;
 
 public final class Container {
     private final JsonNode node;
@@ -15,6 +16,17 @@ public final class Container {
 
     public Env getEnv() {
         return new Env(node.path("env"));
+    }
+
+    public JsonNode getVolumeMounts() {
+        return node.path("volumeMounts");
+    }
+
+    public JsonNode getVolumeMount(String name) {
+        return Array.ofAll(getVolumeMounts())
+                .find(v -> v.path("name").asText().equals(name))
+                .getOrElseThrow(() -> new AssertionError("cannot find the volume mount: " + name));
+
     }
 
 }

--- a/src/test/java/test/model/StatefulSet.java
+++ b/src/test/java/test/model/StatefulSet.java
@@ -3,6 +3,7 @@ package test.model;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.vavr.collection.Array;
 import io.vavr.collection.Seq;
+import io.vavr.control.Option;
 
 /**
  * A specialisation of {@link KubeResource} which adds convenience methods for making StatefulSets easier to handle.
@@ -33,5 +34,14 @@ public final class StatefulSet extends KubeResource {
 
     public Seq<JsonNode> getVolumeClaimTemplates() {
         return Array.ofAll(getSpec().path("volumeClaimTemplates"));
+    }
+
+    public JsonNode getVolumes() {
+        return getPodSpec().required("volumes");
+    }
+
+    public Option<JsonNode> getVolume(String volumeName) {
+        return Array.ofAll(getVolumes())
+                .find(volume -> volume.path("name").asText().equals(volumeName));
     }
 }


### PR DESCRIPTION
Defining additionalFiles in the Jira chart resulted in:

```
Error: UPGRADE FAILED: error validating "": error validating data: [ValidationError(StatefulSet.spec.template.spec.volumes[0]): unknown field "items" in io.k8s.api.core.v1.Volume, ValidationError(StatefulSet.spec.template.spec.volumes[1]): unknown field "items" in io.k8s.api.core.v1.Volume]
```

due to an indentation issue.
While fixing that I also noticed that additionalFiles weren't specified in Confluence's ' volumes' so I've added it there.
Bitbucket's indenting looks fine.