### PR TITLE
DCKUBE-272: Rename port mappings

### DIFF
--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -98,11 +98,11 @@ spec:
             - name: http
               containerPort: {{ .Values.jira.ports.http }}
               protocol: TCP
-            - name: ehcachePort
-              containerPort: {{ .Values.jira.ports.ehcachePort }} 
+            - name: ehcache
+              containerPort: {{ .Values.jira.ports.ehcache }} 
               protocol: TCP 
-            - name: ehcacheObjectPort
-              containerPort: {{ .Values.jira.ports.ehcacheObjectPort }}
+            - name: ehcacheobject
+              containerPort: {{ .Values.jira.ports.ehcacheobject }}
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -58,8 +58,8 @@ jira:
   ports:
     # -- The port on which the Jira container listens for HTTP traffic
     http: 8080
-    ehcachePort: 40001
-    ehcacheObjectPort: 40011 
+    ehcache: 40001
+    ehcacheobject: 40011 
   readinessProbe:
     # -- The initial delay (in seconds) for the Jira container readiness probe, after which the probe will start running
     initialDelaySeconds: 10

--- a/src/test/resources/expected_helm_output/jira/output.yaml
+++ b/src/test/resources/expected_helm_output/jira/output.yaml
@@ -126,10 +126,10 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-            - name: ehcachePort
+            - name: ehcache
               containerPort: 40001 
               protocol: TCP 
-            - name: ehcacheObjectPort
+            - name: ehcacheobject
               containerPort: 40011
               protocol: TCP
           readinessProbe:


### PR DESCRIPTION
Encountered the error below when spinning up Jira with the origina changes: https://github.com/atlassian-labs/data-center-helm-charts/pull/117/files

This change is to address the limitation.

```Events:
  Type     Reason            Age                From                    Message
  ----     ------            ----               ----                    -------
  Normal   SuccessfulCreate  12s                statefulset-controller  create Claim local-home-drathbone-jira-0 Pod drathbone-jira-0 in StatefulSet drathbone-jira success
  Warning  FailedCreate      1s (x12 over 12s)  statefulset-controller  create Pod drathbone-jira-0 in StatefulSet drathbone-jira failed error: Pod "drathbone-jira-0" is invalid: spec.containers[0].ports[1].name: Invalid value: "ehcachePort": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)`


