### PR TITLE
Lower the NFS server requirements and remove storageClass

### DIFF
--- a/src/test/infrastructure/storage/test-nfs-server.yaml
+++ b/src/test/infrastructure/storage/test-nfs-server.yaml
@@ -1,0 +1,135 @@
+### TEST TEMPLATE ONLY (works on AWS only)
+###
+### This template serves as an example how to deploy a very simple NFS server providing persistent volumes
+### in read write many mode (as all the application nodes require to access the shared home from one persistent volume).
+### More visual representation can be found in official kubernetes repository:
+### https://github.com/kubernetes/examples/tree/master/staging/volumes/nfs
+
+### For NFS server you should be using fast underlying storage as it will directly impact performance for your Bitbucket
+### instance. Please see documentation specific for your kubernetes cluster infrastructure.
+#---
+#
+#kind: StorageClass
+#apiVersion: storage.k8s.io/v1
+#metadata:
+#  name: io1-fast
+#  annotations:
+#    storageclass.kubernetes.io/is-default-class: "false"
+#  labels:
+#    build.identifier: CI_PLAN_ID
+#    build.component: nfs-server-storage-class
+#provisioner: kubernetes.io/aws-ebs
+#parameters:
+#  type: io1
+#  iopsPerGB: "10"
+#  encrypted: "true"
+#  fsType: ext4
+
+
+### PersistentVolumeClaim will dynamically create the persistent volume based on the defined storageClassName.
+### This will spare you the manual step when you need to create the underlying volume manually and then
+### define PersistentVolume for it. You might still prefer that approach as it will give you more control over
+### your data
+---
+
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: CI_PLAN_ID-data-pvc
+  labels:
+    build.identifier: CI_PLAN_ID
+    build.component: nfs-server-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+#  storageClassName: io1-fast # if you want more performant storage, also you need to uncomment StorageClass definition
+  resources:
+    requests:
+      storage: 1Gi # make sure you have enough space for your shared home
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: CI_PLAN_ID
+  labels:
+    build.identifier: CI_PLAN_ID
+    build.component: nfs-server-service
+spec:
+  type: LoadBalancer
+  ports:
+    - name: nfs
+      port: 2049
+    - name: mountd
+      port: 20048
+    - name: rpcbind
+      port: 111
+  selector:
+    role: CI_PLAN_ID
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: CI_PLAN_ID
+  labels:
+    build.identifier: CI_PLAN_ID
+    build.component: nfs-server-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      role: CI_PLAN_ID
+  template:
+    metadata:
+      labels:
+        role: CI_PLAN_ID
+    spec:
+      containers:
+        - name: CI_PLAN_ID
+          image: atlassian/nfs-server-test:latest # this is just a testing image not recommended for any other use case
+          imagePullPolicy: Always
+          ports:
+            - name: nfs
+              containerPort: 2049
+            - name: mountd
+              containerPort: 20048
+            - name: rpcbind
+              containerPort: 111
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+                - SYS_MODULE
+          volumeMounts:
+            - name: CI_PLAN_ID-data-pvc
+              mountPath: /srv/nfs
+            - name: CI_PLAN_ID-conf
+              mountPath: /etc/exports.d/
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 512Mi
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: CI_PLAN_ID-data-pvc
+          persistentVolumeClaim:
+            claimName: CI_PLAN_ID-data-pvc
+        - name: CI_PLAN_ID-conf
+          configMap:
+            name: CI_PLAN_ID-conf
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: CI_PLAN_ID-conf
+  labels:
+    build.identifier: CI_PLAN_ID
+    build.component: nfs-server-configmap
+data:
+  share.exports: |-
+    /srv/nfs *(rw,subtree_check,fsid=0,no_root_squash)

--- a/src/test/scripts/helm_uninstall.sh
+++ b/src/test/scripts/helm_uninstall.sh
@@ -11,8 +11,7 @@ PRODUCT_RELEASE_NAME=$RELEASE_PREFIX-$PRODUCT_NAME
 POSTGRES_RELEASE_NAME=$PRODUCT_RELEASE_NAME-pgsql
 FUNCTEST_RELEASE_NAME=$PRODUCT_RELEASE_NAME-functest
 
-ARCHITECTURE_EXAMPLE_DIR='../../../reference-infrastructure'
-NFS_SERVER_YAML="${ARCHITECTURE_EXAMPLE_DIR}/storage/nfs/nfs-server.yaml"
+NFS_SERVER_YAML="$BASEDIR/../infrastructure/storage/test-nfs-server.yaml"
 
 helm uninstall -n "${TARGET_NAMESPACE}" "${FUNCTEST_RELEASE_NAME}" || true
 helm uninstall -n "${TARGET_NAMESPACE}" "${PRODUCT_RELEASE_NAME}" || true

--- a/src/test/scripts/start_nfs_server.sh
+++ b/src/test/scripts/start_nfs_server.sh
@@ -11,14 +11,13 @@ fi
 TARGET_NAMESPACE=$1
 PRODUCT_RELEASE_NAME=$2
 
-ARCH_EXAMPLE_DIR="$BASEDIR/../../../reference-infrastructure"
-NFS_SERVER_YAML="${ARCH_EXAMPLE_DIR}/storage/nfs/nfs-server.yaml"
+NFS_SERVER_YAML="$BASEDIR/../infrastructure/storage/test-nfs-server.yaml"
 
 echo Deleting old NFS resources...
 kubectl delete -f $NFS_SERVER_YAML --ignore-not-found=true || true
 
 echo Starting NFS deployment...
-sed -e "s/test-nfs-server/$PRODUCT_RELEASE_NAME-nfs-server/" $NFS_SERVER_YAML | kubectl apply -n "${TARGET_NAMESPACE}" -f -
+sed -e "s/CI_PLAN_ID/$PRODUCT_RELEASE_NAME-nfs-server/" $NFS_SERVER_YAML | kubectl apply -n "${TARGET_NAMESPACE}" -f -
 
 echo Waiting until the NFS deployment is ready...
 pod_role="$PRODUCT_RELEASE_NAME-nfs-server"


### PR DESCRIPTION
I decided to move away from the reference infrastructure. I think we are mixing two concerns together - throwaway infrastructure for testing and an example for customers. I think this is keeping it cleaner for customers.

It also separates our requirements:
* need to be able to run in the local environment (use default storage class)
* lower the computational resources (so the builds are not draining our CI capacity)

I haven't made a decision whether to remove the `test-` prefix for the resources in https://github.com/atlassian-labs/data-center-helm-charts/blob/master/reference-infrastructure/storage/nfs/nfs-server.yaml
To some degree, it is still NFS Server for testing purposes. 

Just to learn `kustomize` I've tried to see how this change would look like in it - https://github.com/atlassian-labs/data-center-helm-charts/pull/124
I must say I much prefer the simplicity of this solution. I think I would rather have either very simple yaml files with `sed` or proper full helm chart. Kustomize is somewhere in the middle and I find it clunky.