### PR TITLE
DCKUBE-205: fix a provisioning a problem when debug flag is false

### DIFF
--- a/src/main/charts/confluence/templates/config-jvm.yaml
+++ b/src/main/charts/confluence/templates/config-jvm.yaml
@@ -11,7 +11,7 @@ data:
     {{ include "confluence.sysprop.enable.synchrony.by.default" . }}
     {{ include "confluence.sysprop.clusterNodeName" . }}
     {{ include "confluence.sysprop.fluentdAppender" . }}
-    {{ include "confluence.sysprop.debug" . }}
+    {{- include "confluence.sysprop.debug" . -}}
     {{- range .Values.confluence.additionalJvmArgs }}
     {{ . }}
     {{- end }}


### PR DESCRIPTION
If the parameter `confluence.jvmDebug.enabled` is false, Confluence provisioning fails because of incorrectly formatted JVM arguments. This PR fixes the problem.