### PR TITLE
DCKUBE-292: fix the problem with empty ingress URL in Confluence

### DIFF
--- a/src/main/charts/confluence/templates/ingress-setup.yaml
+++ b/src/main/charts/confluence/templates/ingress-setup.yaml
@@ -30,7 +30,7 @@ spec:
     - host: {{ .Values.ingress.host }}
       http:
         paths:
-          - path: "{{ .Values.ingress.path }}/setup"
+          - path: "{{ trimSuffix "/" .Values.ingress.path }}/setup"
             backend:
               serviceName: {{ include "confluence.fullname" . }}
               servicePort: {{ $.Values.confluence.service.port }}

--- a/src/main/charts/confluence/templates/ingress.yaml
+++ b/src/main/charts/confluence/templates/ingress.yaml
@@ -35,7 +35,7 @@ spec:
               serviceName: {{ include "confluence.fullname" . }}
               servicePort: {{ $.Values.confluence.service.port }}
           {{ if .Values.synchrony.enabled }}
-          - path: "{{ .Values.ingress.path }}/synchrony"
+          - path: "{{ trimSuffix "/" .Values.ingress.path }}/synchrony"
             backend:
               serviceName: {{ include "synchrony.fullname" . }}
               servicePort: {{ $.Values.synchrony.service.port }}


### PR DESCRIPTION
Right now default `/` ingress path generates double slash in Confluence ingresses:

```
  rules:
    - host: efims-macbook.local
      http:
        paths:
          - path: /
            backend:
              serviceName: epyshnograev-confluence
              servicePort: 80

          - path: "//synchrony"
            backend:
              serviceName: epyshnograev-confluence-synchrony
              servicePort: 80
```

This pull request trims the extra slash before concatenating it with subpath.