### PR TITLE
DCKUBE-322: Add resources stanza for Synchrony and inject values into startup

### DIFF
--- a/src/main/charts/confluence/templates/synchrony-start-script.yaml
+++ b/src/main/charts/confluence/templates/synchrony-start-script.yaml
@@ -11,6 +11,8 @@ data:
     #!/usr/bin/env bash
 
     java \
+       -Xss{{ .Values.synchrony.resources.jvm.stackSize }} -Xmx{{ .Values.synchrony.resources.jvm.maxHeap }} \
+       -XX:ActiveProcessorCount={{ .Values.synchrony.resources.container.requests.cpu }} \
        -classpath /opt/atlassian/confluence/confluence/WEB-INF/packages/synchrony-standalone.jar:/opt/atlassian/confluence/confluence/WEB-INF/lib/* \
        synchrony.core \
        sql

--- a/src/main/charts/confluence/templates/synchrony-start-script.yaml
+++ b/src/main/charts/confluence/templates/synchrony-start-script.yaml
@@ -11,7 +11,9 @@ data:
     #!/usr/bin/env bash
 
     java \
-       -Xss{{ .Values.synchrony.resources.jvm.stackSize }} -Xmx{{ .Values.synchrony.resources.jvm.maxHeap }} \
+       -Xms{{ .Values.synchrony.resources.jvm.minHeap }} \
+       -Xmx{{ .Values.synchrony.resources.jvm.maxHeap }} \
+       -Xss{{ .Values.synchrony.resources.jvm.stackSize }} \
        -XX:ActiveProcessorCount={{ .Values.synchrony.resources.container.requests.cpu }} \
        -classpath /opt/atlassian/confluence/confluence/WEB-INF/packages/synchrony-standalone.jar:/opt/atlassian/confluence/confluence/WEB-INF/lib/* \
        synchrony.core \

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -183,6 +183,18 @@ synchrony:
     periodSeconds: 1
     # -- The number of consecutive failures of the Synchrony container readiness probe before the pod fails readiness checks
     failureThreshold: 30
+  resources:
+    jvm:
+      # -- The maximum amount of heap memory that will be used by the Synchrony JVM
+      maxHeap: "1g"
+      # -- The minimum amount of heap memory that will be used by the Synchrony JVM
+      minHeap: "1g"
+      # -- The memory allocated for the Synchrony stack
+      stackSize: "2048k"
+    container: 
+      requests:
+        cpu: "2"
+        memory: "2G"
   # -- The base URL of the Synchrony service.
   # This will be the URL that users' browsers will be given to communicate with Synchrony, as well as the URL that the
   # Confluence service will use to communicate directly with Synchrony, so the URL must be resovable both from inside and

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -188,7 +188,7 @@ synchrony:
       # -- The maximum amount of heap memory that will be used by the Synchrony JVM
       maxHeap: "1g"
       # -- The minimum amount of heap memory that will be used by the Synchrony JVM
-      minHeap: "1g"
+      minHeap: "2g"
       # -- The memory allocated for the Synchrony stack
       stackSize: "2048k"
     container: 

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -185,16 +185,16 @@ synchrony:
     failureThreshold: 30
   resources:
     jvm:
-      # -- The maximum amount of heap memory that will be used by the Synchrony JVM
-      maxHeap: "1g"
       # -- The minimum amount of heap memory that will be used by the Synchrony JVM
-      minHeap: "2g"
+      minHeap: "1g"
+      # -- The maximum amount of heap memory that will be used by the Synchrony JVM
+      maxHeap: "2g"
       # -- The memory allocated for the Synchrony stack
       stackSize: "2048k"
     container: 
       requests:
         cpu: "2"
-        memory: "2G"
+        memory: "2.5G"
   # -- The base URL of the Synchrony service.
   # This will be the URL that users' browsers will be given to communicate with Synchrony, as well as the URL that the
   # Confluence service will use to communicate directly with Synchrony, so the URL must be resovable both from inside and

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -165,7 +165,7 @@ synchrony:
   # -- True if Synchrony (i.e. collaborative editing) should be enabled.
   # This will result in a separate StatefulSet and Service to be created for Synchrony.
   # If disabled, then collaborative editing will be disabled in Confluence.
-  enabled: false
+  enabled: true
   service:
     # -- The port on which the Synchrony Kubernetes service will listen
     port: 80

--- a/src/test/java/test/SynchronyTest.java
+++ b/src/test/java/test/SynchronyTest.java
@@ -41,10 +41,9 @@ class SynchronyTest {
 
     @ParameterizedTest
     @EnumSource(value = Product.class, names = "confluence")
-    void synchrony_params(Product product) throws Exception {
+    void synchrony_entrypoint(Product product) throws Exception {
         final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
-                "synchrony.enabled", "true",
-                "synchrony.ingressUrl", "https://mysynchrony"
+                "synchrony.enabled", "true"
         ));
 
         final var entrypoint = resources.get(Kind.ConfigMap, product.getHelmReleaseName() + "-synchrony-entrypoint")

--- a/src/test/java/test/SynchronyTest.java
+++ b/src/test/java/test/SynchronyTest.java
@@ -38,4 +38,21 @@ class SynchronyTest {
                 .hasTextContaining("-Dsynchrony.service.url=https://mysynchrony/v1")
                 .hasTextNotContaining("synchrony.btf.disabled");
     }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = "confluence")
+    void synchrony_params(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                "synchrony.enabled", "true",
+                "synchrony.ingressUrl", "https://mysynchrony"
+        ));
+
+        final var entrypoint = resources.get(Kind.ConfigMap, product.getHelmReleaseName() + "-synchrony-entrypoint")
+                .getNode("data", "start-synchrony.sh");
+
+        assertThat(entrypoint)
+                .hasTextContaining("-Xss2048k")
+                .hasTextContaining("-Xmx1g")
+                .hasTextContaining("-XX:ActiveProcessorCount=2");
+    }
 }

--- a/src/test/java/test/SynchronyTest.java
+++ b/src/test/java/test/SynchronyTest.java
@@ -51,7 +51,8 @@ class SynchronyTest {
 
         assertThat(entrypoint)
                 .hasTextContaining("-Xss2048k")
-                .hasTextContaining("-Xmx1g")
+                .hasTextContaining("-Xms1g")
+                .hasTextContaining("-Xmx2g")
                 .hasTextContaining("-XX:ActiveProcessorCount=2");
     }
 }

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -60,7 +60,7 @@ kind: Service
 metadata:
   name: unittest-confluence-synchrony
   labels:
-    helm.sh/chart: confluence-0.9.0
+    helm.sh/chart: confluence-0.10.0
     app.kubernetes.io/name: confluence-synchrony
     app.kubernetes.io/instance: unittest-confluence
     app.kubernetes.io/version: "7.12.0-jdk11"
@@ -112,7 +112,7 @@ kind: StatefulSet
 metadata:
   name: unittest-confluence-synchrony
   labels:
-    helm.sh/chart: confluence-0.9.0
+    helm.sh/chart: confluence-0.10.0
     app.kubernetes.io/name: confluence-synchrony
     app.kubernetes.io/instance: unittest-confluence
     app.kubernetes.io/version: "7.12.0-jdk11"

--- a/src/test/resources/expected_helm_output/confluence/output.yaml
+++ b/src/test/resources/expected_helm_output/confluence/output.yaml
@@ -25,7 +25,7 @@ metadata:
 data:
   additional_jvm_args: >-
     -Dconfluence.cluster.hazelcast.listenPort=5701
-    -Dsynchrony.btf.disabled=true
+    -Dsynchrony.service.url=/v1
     -Dsynchrony.by.default.enable.collab.editing.if.manually.managed=true
     -Dconfluence.clusterNodeName.useHostname=true
     -Datlassian.logging.cloud.enabled=false
@@ -33,6 +33,52 @@ data:
   max_heap: 1g
   min_heap: 1g
   reserved_code_cache: 256m
+---
+# Source: confluence/templates/synchrony-start-script.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unittest-confluence-synchrony-entrypoint
+data:
+  # The script we use as the entrypoint for the Synchrony container, because there isn't one we can use out of the box.
+  # Note that the classpath ony really needs to contain synchrony-standalone.jar and the JDBC driver JAR, but for simplicitly
+  # we just add every JAR in the Confluence lib directory.
+  start-synchrony.sh: |
+    #!/usr/bin/env bash
+    java \
+       -Xms1g \
+       -Xmx2g \
+       -Xss2048k \
+       -XX:ActiveProcessorCount=2 \
+       -classpath /opt/atlassian/confluence/confluence/WEB-INF/packages/synchrony-standalone.jar:/opt/atlassian/confluence/confluence/WEB-INF/lib/* \
+       synchrony.core \
+       sql
+---
+# Source: confluence/templates/service-synchrony.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: unittest-confluence-synchrony
+  labels:
+    helm.sh/chart: confluence-0.9.0
+    app.kubernetes.io/name: confluence-synchrony
+    app.kubernetes.io/instance: unittest-confluence
+    app.kubernetes.io/version: "7.12.0-jdk11"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: 5701
+      targetPort: hazelcast
+      protocol: TCP
+      name: hazelcast
+  selector:
+    app.kubernetes.io/name: confluence-synchrony
+    app.kubernetes.io/instance: unittest-confluence
 ---
 # Source: confluence/templates/service.yaml
 apiVersion: v1
@@ -59,6 +105,70 @@ spec:
   selector:
     app.kubernetes.io/name: confluence
     app.kubernetes.io/instance: unittest-confluence
+---
+# Source: confluence/templates/statefulset-synchrony.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: unittest-confluence-synchrony
+  labels:
+    helm.sh/chart: confluence-0.9.0
+    app.kubernetes.io/name: confluence-synchrony
+    app.kubernetes.io/instance: unittest-confluence
+    app.kubernetes.io/version: "7.12.0-jdk11"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  serviceName: unittest-confluence-synchrony
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: confluence-synchrony
+      app.kubernetes.io/instance: unittest-confluence
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: confluence-synchrony
+        app.kubernetes.io/instance: unittest-confluence
+    spec:
+      serviceAccountName: unittest-confluence
+      terminationGracePeriodSeconds: 1
+      hostAliases:
+      containers:
+        - name: synchrony
+          image: "atlassian/confluence-server:7.12.0-jdk11"
+          imagePullPolicy: IfNotPresent
+          command: ["/scripts/start-synchrony.sh"]
+          volumeMounts:
+            - mountPath: /scripts
+              name: entrypoint-script
+          ports:
+            - name: http
+              containerPort: 8091
+              protocol: TCP
+            - name: hazelcast
+              containerPort: 5701
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              port: 8091
+              path: /heartbeat
+            initialDelaySeconds: 5
+            periodSeconds: 1
+            failureThreshold: 30
+          env:
+            - name: SYNCHRONY_BIND
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: SYNCHRONY_SERVICE_URL
+              value: 
+      volumes:
+        - name: entrypoint-script
+          configMap:
+            name: unittest-confluence-synchrony-entrypoint
+            defaultMode: 0744
+        - name: shared-home
+          emptyDir: {}
 ---
 # Source: confluence/templates/statefulset.yaml
 apiVersion: apps/v1


### PR DESCRIPTION
This adds the resources stanza, and injects those values into the generated Synchrony startup script. The resulting running command looks like:
`java -Xss2048k -Xmx1g -XX:ActiveProcessorCount=2 -classpath /opt/atlassian/confluence/confluence/WEB-INF/packages/synchrony-standalone.jar:/opt/atlassian/confluence/confluence/WEB-INF/lib/* synchrony.core sql`
