### PR TITLE
Fix broken link in the installation guide

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -6,7 +6,7 @@ Use these instructions to install your Atlassian product using the Helm charts. 
 
 Add the Helm chart repository to your local Helm installation:
 
-   `helm repo add atlassian-data-center https://atlassian-labs.github.io/data-center-helm-chart`
+   `helm repo add atlassian-data-center https://atlassian-labs.github.io/data-center-helm-charts`
    
    `helm repo update`
 


### PR DESCRIPTION
There was a typo in the installation guide: helm-chart link was broken. We spent some time before actually guess to append one letter to the link :)