### PR TITLE
DCKUBE-438: increase the timeout for /bootstrap endpoints in the same way as for /setup to avoid the ingress timeout

### DIFF
--- a/src/main/charts/confluence/templates/ingress-setup.yaml
+++ b/src/main/charts/confluence/templates/ingress-setup.yaml
@@ -36,4 +36,11 @@ spec:
                 name: {{ include "confluence.fullname" . }}
                 port:
                   number: {{ $.Values.confluence.service.port }}
+          - path: "{{ trimSuffix "/" .Values.ingress.path }}/bootstrap"
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "confluence.fullname" . }}
+                port:
+                  number: {{ $.Values.confluence.service.port }}
 {{ end }}


### PR DESCRIPTION
This PR will battle timeout during setup which we are seeing in Confluence builds. The problem was partially fixed before when we increased the timeout for `/setup` prefixes, but the same change must be also applied for `/bootstrap` prefixes, as they are also used in the setup.