### PR TITLE
DCKUBE-429 Increase timeout for waiting for pods to come up.

### DIFF
--- a/src/test/scripts/helm_install.sh
+++ b/src/test/scripts/helm_install.sh
@@ -114,7 +114,7 @@ bootstrap_database() {
   # Use the product name for the name of the postgres database, username, and password.
   # These must match the credentials stored in the Secret preloaded into the namespace,
   # which the application will use to connect to the database.
-  helm install -n "${TARGET_NAMESPACE}" --wait \
+  helm install -n "${TARGET_NAMESPACE}" --wait --timeout 15m \
      "$POSTGRES_RELEASE_NAME" \
      --values "$THISDIR/postgres-values.yaml" \
      --set fullnameOverride="$POSTGRES_RELEASE_NAME" \
@@ -198,7 +198,7 @@ package_functest_helm_chart() {
 # Install the product's Helm chart
 install_product() {
   echo "Task 8 - Installing product helm chart." >&2
-  helm install -n "${TARGET_NAMESPACE}" --wait \
+  helm install -n "${TARGET_NAMESPACE}" --wait --timeout 15m \
      "$PRODUCT_RELEASE_NAME" \
      $HELM_DEBUG_OPTION \
      ${valueOverrides} \
@@ -208,7 +208,7 @@ install_product() {
 # Install the functest Helm chart
 install_functional_tests() {
   echo "Task 9 - Installing functional tests." >&2
-  helm install --wait \
+  helm install --wait --timeout 15m \
      -n "${TARGET_NAMESPACE}" \
      "$FUNCTEST_RELEASE_NAME" \
      --set "$FUNCTEST_CHART_VALUES" \

--- a/src/test/scripts/shared_home_browser_install.sh
+++ b/src/test/scripts/shared_home_browser_install.sh
@@ -8,4 +8,4 @@ TARGET_NAMESPACE=$1
 
 echo Starting shared home browser...
 kubectl apply -n "${TARGET_NAMESPACE}" -f "./../../../target/config/shared-home/shared-home-browser.yaml"
-kubectl wait -n "${TARGET_NAMESPACE}" --for=condition=Ready pod/shared-home-browser
+kubectl wait -n "${TARGET_NAMESPACE}" --for=condition=Ready pod/shared-home-browser --timeout 900s

--- a/src/test/scripts/start_nfs_server.sh
+++ b/src/test/scripts/start_nfs_server.sh
@@ -24,7 +24,7 @@ pod_role="$PRODUCT_RELEASE_NAME-nfs-server"
 echo Pod role is [$pod_role]
 pod_name=$(kubectl get pod -n "${TARGET_NAMESPACE}" -l role=$pod_role -o jsonpath="{.items[0].metadata.name}")
 echo Pod name is [$pod_name]
-kubectl wait --for=condition=ready pod -n "${TARGET_NAMESPACE}" "${pod_name}" --timeout=60s
+kubectl wait --for=condition=ready pod -n "${TARGET_NAMESPACE}" "${pod_name}" --timeout=900s
 
 echo Waiting for the container to stabilise...
 while ! kubectl exec -n "${TARGET_NAMESPACE}" "${pod_name}" -- ps -o cmd | grep 'mountd' | grep -q '/usr/sbin/rpc.mountd -N 2 -V 3'; do


### PR DESCRIPTION
Sometimes the cluster-autoscaler takes too long to spin up new
nodes, this timeout should give enough time for it to spin up
nodes and then for the application to come up.