### PR TITLE
DCKUBE-437: Wording improvement for warning in NOTES when PV is not used

### DIFF
--- a/src/main/charts/bitbucket/templates/NOTES.txt
+++ b/src/main/charts/bitbucket/templates/NOTES.txt
@@ -41,7 +41,7 @@ Get the {{ title .Chart.Name }} URL by running these commands in the same shell:
 
 {{ if not ( or .Values.volumes.localHome.persistentVolumeClaim.create .Values.volumes.localHome.customVolume ) }}
 #################################################################################
-######      WARNING: Persistent volume is not used for Local Home!!!       #####
+######      WARNING: Persistent volume is not used for Local Home!!!        #####
 ######            Data will be lost when the pod is terminated.             #####
 #################################################################################
 {{- end }}

--- a/src/main/charts/bitbucket/templates/NOTES.txt
+++ b/src/main/charts/bitbucket/templates/NOTES.txt
@@ -39,9 +39,15 @@ Get the {{ title .Chart.Name }} URL by running these commands in the same shell:
 {{- end }}
 {{- end }}
 
+{{ if not ( or .Values.volumes.localHome.persistentVolumeClaim.create .Values.volumes.localHome.customVolume ) }}
+#################################################################################
+######      WARNING: Persistent volume is not used for Local Home!!!       #####
+######            Data will be lost when the pod is terminated.             #####
+#################################################################################
+{{- end }}
 {{ if not ( or .Values.volumes.sharedHome.persistentVolumeClaim.create .Values.volumes.sharedHome.customVolume ) }}
 #################################################################################
-######              WARNING: Persistent volume is not used!!!               #####
+######      WARNING: Persistent volume is not used for Shared Home!!!       #####
 ######            Data will be lost when the pod is terminated.             #####
 #################################################################################
 {{- end }}

--- a/src/main/charts/confluence/templates/NOTES.txt
+++ b/src/main/charts/confluence/templates/NOTES.txt
@@ -41,7 +41,7 @@ Get the {{ title .Chart.Name }} URL by running these commands in the same shell:
 
 {{ if not ( or .Values.volumes.localHome.persistentVolumeClaim.create .Values.volumes.localHome.customVolume ) }}
 #################################################################################
-######      WARNING: Persistent volume is not used for Local Home!!!       #####
+######      WARNING: Persistent volume is not used for Local Home!!!        #####
 ######            Data will be lost when the pod is terminated.             #####
 #################################################################################
 {{- end }}

--- a/src/main/charts/confluence/templates/NOTES.txt
+++ b/src/main/charts/confluence/templates/NOTES.txt
@@ -39,9 +39,15 @@ Get the {{ title .Chart.Name }} URL by running these commands in the same shell:
 {{- end }}
 {{- end }}
 
+{{ if not ( or .Values.volumes.localHome.persistentVolumeClaim.create .Values.volumes.localHome.customVolume ) }}
+#################################################################################
+######      WARNING: Persistent volume is not used for Local Home!!!       #####
+######            Data will be lost when the pod is terminated.             #####
+#################################################################################
+{{- end }}
 {{ if not ( or .Values.volumes.sharedHome.persistentVolumeClaim.create .Values.volumes.sharedHome.customVolume ) }}
 #################################################################################
-######              WARNING: Persistent volume is not used!!!               #####
+######      WARNING: Persistent volume is not used for Shared Home!!!       #####
 ######            Data will be lost when the pod is terminated.             #####
 #################################################################################
 {{- end }}

--- a/src/main/charts/crowd/templates/NOTES.txt
+++ b/src/main/charts/crowd/templates/NOTES.txt
@@ -41,7 +41,7 @@ Get the {{ title .Chart.Name }} URL by running these commands in the same shell:
 
 {{ if not ( or .Values.volumes.localHome.persistentVolumeClaim.create .Values.volumes.localHome.customVolume ) }}
 #################################################################################
-######      WARNING: Persistent volume is not used for Local Home!!!       #####
+######      WARNING: Persistent volume is not used for Local Home!!!        #####
 ######            Data will be lost when the pod is terminated.             #####
 #################################################################################
 {{- end }}

--- a/src/main/charts/crowd/templates/NOTES.txt
+++ b/src/main/charts/crowd/templates/NOTES.txt
@@ -39,9 +39,15 @@ Get the {{ title .Chart.Name }} URL by running these commands in the same shell:
 {{- end }}
 {{- end }}
 
+{{ if not ( or .Values.volumes.localHome.persistentVolumeClaim.create .Values.volumes.localHome.customVolume ) }}
+#################################################################################
+######      WARNING: Persistent volume is not used for Local Home!!!       #####
+######            Data will be lost when the pod is terminated.             #####
+#################################################################################
+{{- end }}
 {{ if not ( or .Values.volumes.sharedHome.persistentVolumeClaim.create .Values.volumes.sharedHome.customVolume ) }}
 #################################################################################
-######              WARNING: Persistent volume is not used!!!               #####
+######      WARNING: Persistent volume is not used for Shared Home!!!       #####
 ######            Data will be lost when the pod is terminated.             #####
 #################################################################################
 {{- end }}

--- a/src/main/charts/jira/templates/NOTES.txt
+++ b/src/main/charts/jira/templates/NOTES.txt
@@ -41,7 +41,7 @@ Get the {{ title .Chart.Name }} URL by running these commands in the same shell:
 
 {{ if not ( or .Values.volumes.localHome.persistentVolumeClaim.create .Values.volumes.localHome.customVolume ) }}
 #################################################################################
-######      WARNING: Persistent volume is not used for Local Home!!!       #####
+######      WARNING: Persistent volume is not used for Local Home!!!        #####
 ######            Data will be lost when the pod is terminated.             #####
 #################################################################################
 {{- end }}

--- a/src/main/charts/jira/templates/NOTES.txt
+++ b/src/main/charts/jira/templates/NOTES.txt
@@ -39,9 +39,15 @@ Get the {{ title .Chart.Name }} URL by running these commands in the same shell:
 {{- end }}
 {{- end }}
 
+{{ if not ( or .Values.volumes.localHome.persistentVolumeClaim.create .Values.volumes.localHome.customVolume ) }}
+#################################################################################
+######      WARNING: Persistent volume is not used for Local Home!!!       #####
+######            Data will be lost when the pod is terminated.             #####
+#################################################################################
+{{- end }}
 {{ if not ( or .Values.volumes.sharedHome.persistentVolumeClaim.create .Values.volumes.sharedHome.customVolume ) }}
 #################################################################################
-######              WARNING: Persistent volume is not used!!!               #####
+######      WARNING: Persistent volume is not used for Shared Home!!!       #####
 ######            Data will be lost when the pod is terminated.             #####
 #################################################################################
 {{- end }}


### PR DESCRIPTION
When helm chart is installed without persistent volume, a warning will be printed out in the post-install note. 
However, the warning was for Shared Home only. Now added local home PV checking as well, and made separate warnings for each, which hopefully will reduce ambiguity. 