### PR TITLE
DCKUBE-474: Added Jira Proxy information to helm chart

### DIFF
--- a/src/main/charts/jira/templates/_helpers.tpl
+++ b/src/main/charts/jira/templates/_helpers.tpl
@@ -34,6 +34,24 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Create default value for ingress port
+*/}}
+{{- define "jira.ingressPort" -}}
+{{ default (ternary "443" "80" .Values.ingress.https) .Values.ingress.port -}}
+{{- end }}
+
+{{/*
+Create default value for ingress path
+*/}}
+{{- define "jira.ingressPath" -}}
+{{- if .Values.ingress.path -}}
+{{- .Values.ingress.path -}}
+{{- else -}}
+{{ default ( "/" ) .Values.jira.service.contextPath -}}
+{{- end }}
+{{- end }}
+
+{{/*
 The name of the service account to be used.
 If the name is defined in the chart values, then use that,
 else if we're creating a new service account then use the name of the Helm release,

--- a/src/main/charts/jira/templates/ingress.yaml
+++ b/src/main/charts/jira/templates/ingress.yaml
@@ -29,7 +29,7 @@ spec:
     - host: {{ .Values.ingress.host }}
       http:
         paths:
-          - path: {{ .Values.ingress.path }}
+          - path: {{ include "jira.ingressPath" . }}
             pathType: Prefix
             backend:
               service:

--- a/src/main/charts/jira/templates/statefulset.yaml
+++ b/src/main/charts/jira/templates/statefulset.yaml
@@ -58,6 +58,12 @@ spec:
             - name: ATL_TOMCAT_CONTEXTPATH
               value: {{ .Values.jira.service.contextPath | quote }}
             {{ end }}
+            {{ if .Values.ingress.host }}
+            - name: ATL_PROXY_NAME
+              value: {{ .Values.ingress.host | quote }}
+            - name: ATL_PROXY_PORT
+              value: {{ include "jira.ingressPort" . | quote }}
+            {{ end }}
             {{- include "jira.databaseEnvVars" . | nindent 12 }}
             {{- include "jira.clusteringEnvVars" . | nindent 12 }}
             {{ with .Values.jira.license.secretName }}

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -315,7 +315,7 @@ ingress:
   # 'ingress.host' value of 'company.k8s.com' this would result in a URL of 
   # 'company.k8s.com/jira'. Default value is 'jira.service.contextpath'
   #
-  #path: '/'
+  path:
   
   # -- The custom annotations that should be applied to the Ingress Resource 
   # when NOT using the K8s ingress-nginx controller.

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -313,9 +313,9 @@ ingress:
    
   # -- The base path for the Ingress Resource. For example '/jira'. Based on a 
   # 'ingress.host' value of 'company.k8s.com' this would result in a URL of 
-  # 'company.k8s.com/jira'
+  # 'company.k8s.com/jira'. Default value is 'jira.service.contextpath'
   #
-  path: "/"
+  #path: '/'
   
   # -- The custom annotations that should be applied to the Ingress Resource 
   # when NOT using the K8s ingress-nginx controller.

--- a/src/test/java/test/IngressTest.java
+++ b/src/test/java/test/IngressTest.java
@@ -123,4 +123,91 @@ class IngressTest {
         // This is because Connie provisions a regular ingress + an ingress for /setup paths with increased timeout
         Assertions.assertEquals(2, ingresses.size());
     }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = "jira")
+    void jira_ingress_host_port(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                "ingress.host", "myhost.mydomain",
+                "ingress.port", "666"));
+
+        resources.getStatefulSet(product.getHelmReleaseName()).getContainer().getEnv()
+                .assertHasValue("ATL_PROXY_NAME", "myhost.mydomain")
+                .assertHasValue("ATL_PROXY_PORT", "666");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = "jira")
+    void jira_ingress_port(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                "ingress.host", "myhost.mydomain"));
+
+        resources.getStatefulSet(product.getHelmReleaseName()).getContainer().getEnv()
+                .assertHasValue("ATL_PROXY_NAME", "myhost.mydomain")
+                .assertHasValue("ATL_PROXY_PORT", "443");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = "jira")
+    void jira_ingress_port_http(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                "ingress.host", "myhost.mydomain",
+                "ingress.https", "False"));
+
+        resources.getStatefulSet(product.getHelmReleaseName()).getContainer().getEnv()
+                .assertHasValue("ATL_PROXY_NAME", "myhost.mydomain")
+                .assertHasValue("ATL_PROXY_PORT", "80");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = "jira")
+    void jira_ingress_path_contextPath(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                "ingress.create", "true",
+                "ingress.host", "myhost.mydomain",
+                "jira.service.contextPath", "/jira-tmp"));
+
+        final var ingresses = resources.getAll(Kind.Ingress);
+        Assertions.assertNotEquals(0, ingresses.size());
+
+        for (KubeResource ingress : ingresses) {
+            assertThat(ingress.getNode("spec", "rules").required(0).path("http").path("paths").required(0).path("path"))
+                    .hasTextContaining("/jira-tmp");
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = "jira")
+    void jira_ingress_path_value(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                "ingress.create", "true",
+                "ingress.host", "myhost.mydomain",
+                "jira.service.contextPath", "/context",
+                "ingress.path", "/ingress"));
+
+        final var ingresses = resources.getAll(Kind.Ingress);
+        Assertions.assertNotEquals(0, ingresses.size());
+
+        for (KubeResource ingress : ingresses) {
+            assertThat(ingress.getNode("spec", "rules").required(0).path("http").path("paths").required(0).path("path"))
+                    .hasTextContaining("/ingress");
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Product.class, names = "jira")
+    void jira_ingress_path_default(Product product) throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(product, Map.of(
+                "ingress.create", "true",
+                "ingress.host", "myhost.mydomain"));
+
+        final var ingresses = resources.getAll(Kind.Ingress);
+        Assertions.assertNotEquals(0, ingresses.size());
+
+        for (KubeResource ingress : ingresses) {
+            assertThat(ingress.getNode("spec", "rules").required(0).path("http").path("paths").required(0).path("path"))
+                    .hasTextContaining("/");
+        }
+    }
+
 }


### PR DESCRIPTION
Added default value for ingress.path and also introduced ALT_PROXY_NAME and ALT_PROXY_PORT for Jira helm chart