### PR TITLE
Add service annotations for Confluence, Crowd, and Jira

### DIFF
--- a/src/main/charts/confluence/templates/service.yaml
+++ b/src/main/charts/confluence/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "confluence.fullname" . }}
   labels:
     {{- include "confluence.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.confluence.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.confluence.service.type }}
   ports:

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -27,7 +27,7 @@
 #
 replicaCount: 1
 
-# Image configuration 
+# Image configuration
 #
 image:
 
@@ -376,6 +376,10 @@ confluence:
     # will be set automatically.
     #
     contextPath:
+
+    # -- Additional annotations to apply to the Service
+    #
+    annotations: {}
   
   # Enable or disable security context in StatefulSet template spec. Enabled 
   # by default with UID 2002. Disable when deploying to OpenShift, unless anyuid 

--- a/src/main/charts/crowd/templates/service.yaml
+++ b/src/main/charts/crowd/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "crowd.fullname" . }}
   labels:
     {{- include "crowd.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.crowd.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.crowd.service.type }}
   ports:

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -116,6 +116,10 @@ crowd:
     #
     type: ClusterIP
 
+    # -- Additional annotations to apply to the Service
+    #
+    annotations: {}
+
   # Enable or disable security context in StatefulSet template spec. Enabled
   # by default with UID 2002. Disable when deploying to OpenShift, unless anyuid
   # policy is attached to a service account.

--- a/src/main/charts/jira/templates/service.yaml
+++ b/src/main/charts/jira/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "jira.fullname" . }}
   labels:
     {{- include "jira.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.jira.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.jira.service.type }}
   ports:

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -191,7 +191,7 @@ volumes:
     # persistentVolumeClaim:
     #   claimName: "<pvc>" 
     
-    # -- Specifies the path in the Jira container to which the local-home volume will be 
+    # -- Specifies the path in the Jira container to which the local-home volume will be
     # mounted.
     #
     mountPath: "/var/atlassian/application-data/jira"
@@ -358,6 +358,10 @@ jira:
     # will be set automatically.
     #
     contextPath:
+
+    # -- Additional annotations to apply to the Service
+    #
+    annotations: {}
     
   # Enable or disable security context in StatefulSet template spec. Enabled 
   # by default with UID 2001. Disable when deploying to OpenShift, unless anyuid 


### PR DESCRIPTION
Add option for additional service annotations. Was already implemented for Bitbucket.