### PR TITLE
Fix the edit link on the documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,6 @@ doc-build:
 	@docker run --rm -it -v ${PWD}/docs:/docs squidfunk/mkdocs-material build
 
 doc-serve:
-	@docker run --rm -it -v ${PWD}/docs:/docs squidfunk/mkdocs-material serve
+	@docker run --rm -it -p 8000:8000 -v ${PWD}/docs:/docs squidfunk/mkdocs-material
 
 docs: doc-docker doc-serve

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
     - navigation.tabs
 repo_url: https://github.com/atlassian-labs/data-center-helm-charts
 repo_name: atlassian-labs/data-center-helm-charts
+edit_uri: edit/master/docs/docs/
 plugins:
   - search
   - awesome-pages


### PR DESCRIPTION
The link (pencil icon on each page) is now pointing to the correct location.
Also fixed local deployment from `make`.