### PR TITLE
DCKUBE-593: use default storage class of the NFS server

### DIFF
--- a/src/test/infrastructure/nfs-server/templates/statefulset.yaml
+++ b/src/test/infrastructure/nfs-server/templates/statefulset.yaml
@@ -125,7 +125,7 @@ spec:
         {{- end }}
       spec:
         accessModes: [ "ReadWriteOnce" ]
-        {{- if .Values.persistence.storageClassName }}
+        {{- if not (kindIs "invalid" .Values.persistence.storageClassName) }}
         storageClassName: {{ .Values.persistence.storageClassName | quote }}
         {{- end }}
         resources:

--- a/src/test/infrastructure/nfs-server/templates/statefulset.yaml
+++ b/src/test/infrastructure/nfs-server/templates/statefulset.yaml
@@ -125,7 +125,7 @@ spec:
         {{- end }}
       spec:
         accessModes: [ "ReadWriteOnce" ]
-        storageClassName: {{ .Values.persistence.storageClassName | default "gp2" }}
+        storageClassName: {{ .Values.persistence.storageClassName }}
         resources:
           requests:
             storage: {{ .Values.persistence.size | default "1Gi" }}

--- a/src/test/infrastructure/nfs-server/templates/statefulset.yaml
+++ b/src/test/infrastructure/nfs-server/templates/statefulset.yaml
@@ -125,7 +125,9 @@ spec:
         {{- end }}
       spec:
         accessModes: [ "ReadWriteOnce" ]
-        storageClassName: {{ .Values.persistence.storageClassName }}
+        {{- if .Values.persistence.storageClassName }}
+        storageClassName: {{ .Values.persistence.storageClassName | quote }}
+        {{- end }}
         resources:
           requests:
             storage: {{ .Values.persistence.size | default "1Gi" }}

--- a/src/test/infrastructure/nfs-server/values.yaml
+++ b/src/test/infrastructure/nfs-server/values.yaml
@@ -57,7 +57,7 @@ persistence:
   annotations: {}
   size: 5Gi
   # If set to nonempty string value, this will specify the storage class to be used.
-  # If left empty, the default Storage Class will be utilised.
+  # If left without value, the default Storage Class will be utilised.
   # Alternatively, can be set to the empty string, to indicate that no Storage Class should be used here.
   storageClassName:
 

--- a/src/test/infrastructure/nfs-server/values.yaml
+++ b/src/test/infrastructure/nfs-server/values.yaml
@@ -56,9 +56,9 @@ service:
 persistence:
   annotations: {}
   size: 5Gi
-  # If set to nonempty string value, this will specify the storage class to be used.
+  # If set to non-empty string value, this will specify the storage class to be used.
   # If left without value, the default Storage Class will be utilised.
-  # Alternatively, can be set to the empty string, to indicate that no Storage Class should be used here.
+  # Alternatively, can be set to the empty string "", to indicate that no Storage Class should be used here.
   storageClassName:
 
 resources:

--- a/src/test/infrastructure/nfs-server/values.yaml
+++ b/src/test/infrastructure/nfs-server/values.yaml
@@ -56,8 +56,9 @@ service:
 persistence:
   annotations: {}
   size: 5Gi
-  # Use the default storage class name
-  storageClassName:
+  # If specified, this Storage Class will be used to provision the NFS PVC.
+  # If left as an empty sting, the default Storage Class will be used.
+  storageClassName: ""
 
 resources:
   # limits:

--- a/src/test/infrastructure/nfs-server/values.yaml
+++ b/src/test/infrastructure/nfs-server/values.yaml
@@ -56,9 +56,10 @@ service:
 persistence:
   annotations: {}
   size: 5Gi
-  # If specified, this Storage Class will be used to provision the NFS PVC.
-  # If left as an empty sting, the default Storage Class will be used.
-  storageClassName: ""
+  # If the string is set to nonempty value, this will specify the storage class to be used.
+  # If left empty, the default Storage Class will be utilised.
+  # Alternatively, can be set to the empty string, to indicate that no Storage Class should be used here.
+  storageClassName:
 
 resources:
   # limits:

--- a/src/test/infrastructure/nfs-server/values.yaml
+++ b/src/test/infrastructure/nfs-server/values.yaml
@@ -56,7 +56,7 @@ service:
 persistence:
   annotations: {}
   size: 5Gi
-  # If the string is set to nonempty value, this will specify the storage class to be used.
+  # If set to nonempty string value, this will specify the storage class to be used.
   # If left empty, the default Storage Class will be utilised.
   # Alternatively, can be set to the empty string, to indicate that no Storage Class should be used here.
   storageClassName:

--- a/src/test/infrastructure/nfs-server/values.yaml
+++ b/src/test/infrastructure/nfs-server/values.yaml
@@ -56,7 +56,8 @@ service:
 persistence:
   annotations: {}
   size: 5Gi
-  storageClassName: "gp2"
+  # Use the default storage class name
+  storageClassName:
 
 resources:
   # limits:


### PR DESCRIPTION
Local execution has been broken since this change. It was trying to provision an NFS Server using the gp2 Storage Class, which is available in AWS, but not in Docker for Mac.

This pull request uses the default Storage Class for NFS Server instead. It fixes the local execution, and it's also supposed to work in AWS, since the gp2 storage class is default there.

* [Confluence build](https://server-syd-bamboo.internal.atlassian.com/browse/CONFA3CLUSTER-K8S37-2)
* [Bitbucket build](https://server-syd-bamboo.internal.atlassian.com/browse/BSERV-K8S17-4)