### PR TITLE
Fix the chart releaser process

### DIFF
--- a/cr.yaml
+++ b/cr.yaml
@@ -1,2 +1,2 @@
-pages-branch: main
-index-path: docs/index.yaml
+pages-branch: gh-pages
+index-path: docs/docs/index.yaml


### PR DESCRIPTION
Since we have switched to using `gh-pages`, it should be possible to start using the helm releaser.
https://github.com/helm/chart-releaser-action

- [ ] enable the github action