### PR TITLE
Change the Home link to documentation

### DIFF
--- a/src/main/charts/README.md.gotmpl
+++ b/src/main/charts/README.md.gotmpl
@@ -5,7 +5,7 @@
 
 {{ template "chart.description" . }}
 
-For installation please follow [the documentation in the repository](https://atlassian-labs.github.io/data-center-helm-charts/).
+For installation please follow [the documentation](https://atlassian-labs.github.io/data-center-helm-charts/).
 
 {{ template "chart.homepageLine" . }}
 

--- a/src/main/charts/bitbucket/Chart.yaml
+++ b/src/main/charts/bitbucket/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - Bitbucket Data Center
   - Bitbucket DC
   - Atlassian
-home: https://www.atlassian.com/software/bitbucket
+home: https://atlassian-labs.github.io/data-center-helm-charts/
 icon: https://atlassian-labs.github.io/data-center-helm-charts/icons/bitbucket.svg
 sources:
   - https://github.com/atlassian-labs/data-center-helm-charts

--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -4,9 +4,9 @@
 
 A chart for installing Bitbucket Data Center on Kubernetes
 
-For installation please follow [the documentation in the repository](https://atlassian-labs.github.io/data-center-helm-charts/).
+For installation please follow [the documentation](https://atlassian-labs.github.io/data-center-helm-charts/).
 
-**Homepage:** <https://www.atlassian.com/software/bitbucket>
+**Homepage:** <https://atlassian-labs.github.io/data-center-helm-charts/>
 
 ## Source Code
 

--- a/src/main/charts/confluence/Chart.yaml
+++ b/src/main/charts/confluence/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - Confluence Data Center
   - Confluence DC
   - Atlassian
-home: https://www.atlassian.com/software/confluence
+home: https://atlassian-labs.github.io/data-center-helm-charts/
 icon: https://atlassian-labs.github.io/data-center-helm-charts/icons/confluence.svg
 sources:
   - https://github.com/atlassian-labs/data-center-helm-charts

--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -4,9 +4,9 @@
 
 A chart for installing Confluence Data Center on Kubernetes
 
-For installation please follow [the documentation in the repository](https://atlassian-labs.github.io/data-center-helm-charts/).
+For installation please follow [the documentation](https://atlassian-labs.github.io/data-center-helm-charts/).
 
-**Homepage:** <https://www.atlassian.com/software/confluence>
+**Homepage:** <https://atlassian-labs.github.io/data-center-helm-charts/>
 
 ## Source Code
 

--- a/src/main/charts/crowd/Chart.yaml
+++ b/src/main/charts/crowd/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - Crowd Data Center
   - Crowd DC
   - Atlassian
-home: https://www.atlassian.com/software/crowd
+home: https://atlassian-labs.github.io/data-center-helm-charts/
 icon: https://atlassian-labs.github.io/data-center-helm-charts/icons/crowd.svg
 sources:
   - https://github.com/atlassian-labs/data-center-helm-charts

--- a/src/main/charts/crowd/README.md
+++ b/src/main/charts/crowd/README.md
@@ -4,9 +4,9 @@
 
 A chart for installing Crowd Data Center on Kubernetes
 
-For installation please follow [the documentation in the repository](https://atlassian-labs.github.io/data-center-helm-charts/).
+For installation please follow [the documentation](https://atlassian-labs.github.io/data-center-helm-charts/).
 
-**Homepage:** <https://www.atlassian.com/software/crowd>
+**Homepage:** <https://atlassian-labs.github.io/data-center-helm-charts/>
 
 ## Source Code
 

--- a/src/main/charts/jira/Chart.yaml
+++ b/src/main/charts/jira/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
   - Jira Data Center
   - Jira DC
   - Atlassian
-home: https://www.atlassian.com/software/jira
+home: https://atlassian-labs.github.io/data-center-helm-charts/
 icon: https://atlassian-labs.github.io/data-center-helm-charts/icons/jira-software.svg
 sources:
   - https://github.com/atlassian-labs/data-center-helm-charts

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -4,9 +4,9 @@
 
 A chart for installing Jira Data Center on Kubernetes
 
-For installation please follow [the documentation in the repository](https://atlassian-labs.github.io/data-center-helm-charts/).
+For installation please follow [the documentation](https://atlassian-labs.github.io/data-center-helm-charts/).
 
-**Homepage:** <https://www.atlassian.com/software/jira>
+**Homepage:** <https://atlassian-labs.github.io/data-center-helm-charts/>
 
 ## Source Code
 


### PR DESCRIPTION
Just a simple change to link to our docs instead of products (which are linked to cloud versions by default anyway)

<img width="266" alt="Screen Shot 2021-08-19 at 12 04 06 pm" src="https://user-images.githubusercontent.com/416238/129995926-a5d3169f-ed61-41cc-a2c3-52795050f627.png">
