### PR TITLE
Issue/dckube 635 fix spacing of the jvm args for debug flag

### DIFF
--- a/src/main/charts/confluence/templates/_helpers.tpl
+++ b/src/main/charts/confluence/templates/_helpers.tpl
@@ -150,9 +150,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{- define "confluence.sysprop.debug" -}}
-{{- if .Values.confluence.jvmDebug.enabled -}}
--Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005
-{{- end }}
+{{- if .Values.confluence.jvmDebug.enabled }} -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 {{ end -}}
 {{- end }}
 
 {{- define "confluence.sysprop.enable.synchrony.by.default" -}}

--- a/src/main/charts/confluence/templates/config-jvm.yaml
+++ b/src/main/charts/confluence/templates/config-jvm.yaml
@@ -11,7 +11,7 @@ data:
     {{ include "confluence.sysprop.enable.synchrony.by.default" . }}
     {{ include "confluence.sysprop.clusterNodeName" . }}
     {{ include "confluence.sysprop.fluentdAppender" . }}
-    {{- include "confluence.sysprop.debug" . -}}
+    {{ include "confluence.sysprop.debug" . -}}
     {{- range .Values.confluence.additionalJvmArgs }}
     {{ . }}
     {{- end }}

--- a/src/main/charts/confluence/templates/config-jvm.yaml
+++ b/src/main/charts/confluence/templates/config-jvm.yaml
@@ -11,7 +11,7 @@ data:
     {{ include "confluence.sysprop.enable.synchrony.by.default" . }}
     {{ include "confluence.sysprop.clusterNodeName" . }}
     {{ include "confluence.sysprop.fluentdAppender" . }}
-    {{ include "confluence.sysprop.debug" . -}}
+    {{- include "confluence.sysprop.debug" . -}}
     {{- range .Values.confluence.additionalJvmArgs }}
     {{ . }}
     {{- end }}

--- a/src/test/java/test/ConfluenceDebugFlagTest.java
+++ b/src/test/java/test/ConfluenceDebugFlagTest.java
@@ -1,0 +1,63 @@
+package test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import test.helm.Helm;
+import test.model.Kind;
+import test.model.Product;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static test.jackson.JsonNodeAssert.assertThat;
+
+class ConfluenceDebugFlagTest {
+    private Helm helm;
+
+    @BeforeEach
+    void initHelm(TestInfo testInfo) {
+        helm = new Helm(testInfo);
+    }
+
+    @Test
+    void withoutDebugFlagJvmArgsFormOneString() throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(Product.confluence, Map.of(
+                "confluence.jvmDebug.enabled", "false"));
+
+        final var configMap = resources.getAll(Kind.ConfigMap)
+                .find(map -> map.getName().endsWith("jvm-config"))
+                .getOrElseThrow(() -> new AssertionError("More than one config map with jvm parameters have been found"));
+
+        assertThat(configMap.getNode("data", "additional_jvm_args"))
+                .hasTextNotContaining("\n");
+
+        assertThat(configMap.getNode("data", "additional_jvm_args"))
+                .hasTextNotContaining("-Xdebug");
+        assertThat(configMap.getNode("data", "additional_jvm_args"))
+                .hasTextNotContaining("-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005");
+    }
+
+    @Test
+    void debugFlagArgumentsAreWellFormed() throws Exception {
+        final var resources = helm.captureKubeResourcesFromHelmChart(Product.confluence, Map.of(
+                "confluence.jvmDebug.enabled", "true"));
+
+        final var configMap = resources.getAll(Kind.ConfigMap)
+                .find(map -> map.getName().endsWith("jvm-config"))
+                .getOrElseThrow(() -> new AssertionError("More than one config map with jvm parameters have been found"));
+
+
+        assertThat(configMap.getNode("data", "additional_jvm_args"))
+                .hasTextNotContaining("\n");
+
+        // The parameter should be surrounded by space characters
+        assertThat(configMap.getNode("data", "additional_jvm_args"))
+                .hasSeparatedTextContaining("-Xdebug");
+
+        assertThat(configMap.getNode("data", "additional_jvm_args"))
+                .hasSeparatedTextContaining("-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005");
+    }
+}

--- a/src/test/java/test/jackson/JsonNodeAssert.java
+++ b/src/test/java/test/jackson/JsonNodeAssert.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import io.vavr.collection.Array;
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.SoftAssertions;
 import org.assertj.vavr.api.VavrAssertions;
 
 import java.util.Map;
@@ -51,10 +54,34 @@ public class JsonNodeAssert extends AbstractAssert<JsonNodeAssert, JsonNode> {
         return this;
     }
 
+    /**
+     * Check that the given text is contained and is positioned either at the beginning/end of the string, or surrounded by spaces
+     * <p>
+     * Examples:
+     * "A B C".hasSeparatedTextContaining("A"); // PASS
+     * "A B C".hasSeparatedTextContaining("B"); // PASS
+     * "A B C".hasSeparatedTextContaining("C"); // PASS
+     * "A  BC".hasSeparatedTextContaining("B"); // FAIL
+     */
+    public JsonNodeAssert hasSeparatedTextContaining(final String expected) {
+        hasTextContaining(expected);
+        doesNotContainRegex(".*[^\\s]" + expected + ".*");
+        doesNotContainRegex(".*" + expected + "[^\\s].*");
+        return this;
+    }
+
     public JsonNodeAssert hasTextNotContaining(final String expected) {
         assertNodeIsOfType(STRING);
         if (actual.asText().contains(expected)) {
             failWithMessage("Expected JsonNode's text to NOT contain <%s> but was <%s>", expected, actual.asText());
+        }
+        return this;
+    }
+
+    public JsonNodeAssert doesNotContainRegex(final String regex) {
+        assertNodeIsOfType(STRING);
+        if (actual.asText().matches(regex)) {
+            failWithMessage("Expected JsonNode's text to NOT contain regex <%s> but was <%s>", regex, actual.asText());
         }
         return this;
     }


### PR DESCRIPTION
If the debug flag was `true`, the following Config Map was generated (notice how `-Xdebug` flag is glued to the previous one). This pull request fixes that problem. I've also added a unit test which verifies JVM arguments in both cases (debug equal to true or false). It took me uncomfortably long time to find the formatting option which actually works.