### PR TITLE
Allow specifying custom ingress-nginx class name.

### DIFF
--- a/src/main/charts/bitbucket/README.md
+++ b/src/main/charts/bitbucket/README.md
@@ -82,6 +82,7 @@ Kubernetes: `>=1.19.x-0`
 | ingress.create | bool | `false` | Set to 'true' if an Ingress Resource should be created. This depends on a  pre-provisioned Ingress Controller being available.  |
 | ingress.host | string | `nil` | The fully-qualified hostname (FQDN) of the Ingress Resource. Traffic coming in on  this hostname will be routed by the Ingress Resource to the appropriate backend  Service. |
 | ingress.https | bool | `true` | Set to 'true' if browser communication with the application should be TLS  (HTTPS) enforced. |
+| ingress.ingressNginxClassName | string | `"nginx"` | The class name used by the 'ingress-nginx' controller if it's being used.  |
 | ingress.maxBodySize | string | `"250m"` | The max body size to allow. Requests exceeding this size will result in an HTTP 413 error being returned to the client. |
 | ingress.nginx | bool | `true` | Set to 'true' if the Ingress Resource is to use the K8s 'ingress-nginx'  controller.  https://kubernetes.github.io/ingress-nginx/ This will populate the Ingress Resource with annotations that are specific to  the K8s ingress-nginx controller. Set to 'false' if a different controller is  to be used, in which case the appropriate annotations for that controller must  be specified below under 'ingress.annotations'. |
 | ingress.path | string | `"/"` | The base path for the Ingress Resource. For example '/bitbucket'. Based on a  'ingress.host' value of 'company.k8s.com' this would result in a URL of  'company.k8s.com/bitbucket' |

--- a/src/main/charts/bitbucket/templates/ingress.yaml
+++ b/src/main/charts/bitbucket/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "bitbucket.labels" . | nindent 4 }}
   annotations:
   {{ if .Values.ingress.nginx }}
-    "kubernetes.io/ingress.class": "nginx"
+    "kubernetes.io/ingress.class": {{ .Values.ingress.ingressNginxClassName }}
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
     "nginx.ingress.kubernetes.io/proxy-body-size": {{ .Values.ingress.maxBodySize }}

--- a/src/main/charts/bitbucket/values.yaml
+++ b/src/main/charts/bitbucket/values.yaml
@@ -361,7 +361,10 @@ ingress:
   # be specified below under 'ingress.annotations'.
   #
   nginx: true
-  
+   
+  # -- The class name used by the 'ingress-nginx' controller if it's being used. 
+  ingressNginxClassName: nginx
+
   # -- The max body size to allow. Requests exceeding this size will result
   # in an HTTP 413 error being returned to the client.
   #

--- a/src/main/charts/confluence/README.md
+++ b/src/main/charts/confluence/README.md
@@ -82,6 +82,7 @@ Kubernetes: `>=1.19.x-0`
 | ingress.create | bool | `false` | Set to 'true' if an Ingress Resource should be created. This depends on a  pre-provisioned Ingress Controller being available.  |
 | ingress.host | string | `nil` | The fully-qualified hostname (FQDN) of the Ingress Resource. Traffic coming in on  this hostname will be routed by the Ingress Resource to the appropriate backend  Service. |
 | ingress.https | bool | `true` | Set to 'true' if browser communication with the application should be TLS  (HTTPS) enforced. |
+| ingress.ingressNginxClassName | string | `"nginx"` | The class name used by the 'ingress-nginx' controller if it's being used.  |
 | ingress.maxBodySize | string | `"250m"` | The max body size to allow. Requests exceeding this size will result in an HTTP 413 error being returned to the client. |
 | ingress.nginx | bool | `true` | Set to 'true' if the Ingress Resource is to use the K8s 'ingress-nginx'  controller.  https://kubernetes.github.io/ingress-nginx/ This will populate the Ingress Resource with annotations that are specific to  the K8s ingress-nginx controller. Set to 'false' if a different controller is  to be used, in which case the appropriate annotations for that controller must  be specified below under 'ingress.annotations'. |
 | ingress.path | string | `"/"` | The base path for the Ingress Resource. For example '/confluence'. Based on a  'ingress.host' value of 'company.k8s.com' this would result in a URL of  'company.k8s.com/confluence' |

--- a/src/main/charts/confluence/templates/ingress-setup.yaml
+++ b/src/main/charts/confluence/templates/ingress-setup.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "confluence.labels" . | nindent 4 }}
   annotations:
     {{ if .Values.ingress.nginx }}
-    "kubernetes.io/ingress.class": "nginx"
+    "kubernetes.io/ingress.class": {{ .Values.ingress.ingressNginxClassName }}
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
     "nginx.ingress.kubernetes.io/proxy-body-size": {{ .Values.ingress.maxBodySize }}

--- a/src/main/charts/confluence/templates/ingress.yaml
+++ b/src/main/charts/confluence/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "confluence.labels" . | nindent 4 }}
   annotations:
     {{ if .Values.ingress.nginx }}
-    "kubernetes.io/ingress.class": "nginx"
+    "kubernetes.io/ingress.class": {{ .Values.ingress.ingressNginxClassName }}
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
     "nginx.ingress.kubernetes.io/proxy-body-size": {{ .Values.ingress.maxBodySize }}

--- a/src/main/charts/confluence/values.yaml
+++ b/src/main/charts/confluence/values.yaml
@@ -318,6 +318,9 @@ ingress:
   #
   nginx: true
   
+  # -- The class name used by the 'ingress-nginx' controller if it's being used. 
+  ingressNginxClassName: nginx
+
   # -- The max body size to allow. Requests exceeding this size will result
   # in an HTTP 413 error being returned to the client.
   #

--- a/src/main/charts/crowd/README.md
+++ b/src/main/charts/crowd/README.md
@@ -71,6 +71,7 @@ Kubernetes: `>=1.19.x-0`
 | ingress.create | bool | `false` | Set to 'true' if an Ingress Resource should be created. This depends on a pre-provisioned Ingress Controller being available. |
 | ingress.host | string | `nil` | The fully-qualified hostname (FQDN) of the Ingress Resource. Traffic coming in on this hostname will be routed by the Ingress Resource to the appropriate backend Service. |
 | ingress.https | bool | `true` | Set to 'true' if browser communication with the application should be TLS (HTTPS) enforced. |
+| ingress.ingressNginxClassName | string | `"nginx"` | The class name used by the 'ingress-nginx' controller if it's being used.  |
 | ingress.maxBodySize | string | `"250m"` | The max body size to allow. Requests exceeding this size will result in an HTTP 413 error being returned to the client. |
 | ingress.nginx | bool | `true` | Set to 'true' if the Ingress Resource is to use the K8s 'ingress-nginx' controller. https://kubernetes.github.io/ingress-nginx/ This will populate the Ingress Resource with annotations that are specific to the K8s ingress-nginx controller. Set to 'false' if a different controller is to be used, in which case the appropriate annotations for that controller must be specified below under 'ingress.annotations'. |
 | ingress.path | string | `"/"` | The base path for the Ingress Resource. For example '/crowd'. Based on a 'ingress.host' value of 'company.k8s.com' this would result in a URL of 'company.k8s.com/crowd' |

--- a/src/main/charts/crowd/templates/ingress.yaml
+++ b/src/main/charts/crowd/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "crowd.labels" . | nindent 4 }}
   annotations:
     {{ if .Values.ingress.nginx }}
-    "kubernetes.io/ingress.class": "nginx"
+    "kubernetes.io/ingress.class": {{ .Values.ingress.ingressNginxClassName }}
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
     "nginx.ingress.kubernetes.io/proxy-body-size": {{ .Values.ingress.maxBodySize }}

--- a/src/main/charts/crowd/values.yaml
+++ b/src/main/charts/crowd/values.yaml
@@ -312,6 +312,9 @@ ingress:
   #
   nginx: true
 
+  # -- The class name used by the 'ingress-nginx' controller if it's being used. 
+  ingressNginxClassName: nginx
+
   # -- The max body size to allow. Requests exceeding this size will result
   # in an HTTP 413 error being returned to the client.
   #

--- a/src/main/charts/jira/README.md
+++ b/src/main/charts/jira/README.md
@@ -49,6 +49,7 @@ Kubernetes: `>=1.19.x-0`
 | ingress.create | bool | `false` | Set to 'true' if an Ingress Resource should be created. This depends on a  pre-provisioned Ingress Controller being available.  |
 | ingress.host | string | `nil` | The fully-qualified hostname (FQDN) of the Ingress Resource. Traffic coming in on  this hostname will be routed by the Ingress Resource to the appropriate backend  Service. |
 | ingress.https | bool | `true` | Set to 'true' if browser communication with the application should be TLS  (HTTPS) enforced. |
+| ingress.ingressNginxClassName | string | `"nginx"` | The class name used by the 'ingress-nginx' controller if it's being used.  |
 | ingress.maxBodySize | string | `"250m"` | The max body size to allow. Requests exceeding this size will result in an HTTP 413 error being returned to the client. |
 | ingress.nginx | bool | `true` | Set to 'true' if the Ingress Resource is to use the K8s 'ingress-nginx'  controller.  https://kubernetes.github.io/ingress-nginx/ This will populate the Ingress Resource with annotations that are specific to  the K8s ingress-nginx controller. Set to 'false' if a different controller is  to be used, in which case the appropriate annotations for that controller must  be specified below under 'ingress.annotations'. |
 | ingress.path | string | `nil` | The base path for the Ingress Resource. For example '/jira'. Based on a  'ingress.host' value of 'company.k8s.com' this would result in a URL of  'company.k8s.com/jira'. Default value is 'jira.service.contextpath' |

--- a/src/main/charts/jira/templates/ingress.yaml
+++ b/src/main/charts/jira/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "jira.labels" . | nindent 4 }}
   annotations:
     {{ if .Values.ingress.nginx }}
-    "kubernetes.io/ingress.class": "nginx"
+    "kubernetes.io/ingress.class": {{ .Values.ingress.ingressNginxClassName }}
     "nginx.ingress.kubernetes.io/affinity": "cookie"
     "nginx.ingress.kubernetes.io/affinity-mode": "persistent"
     "nginx.ingress.kubernetes.io/proxy-body-size": {{ .Values.ingress.maxBodySize }}

--- a/src/main/charts/jira/values.yaml
+++ b/src/main/charts/jira/values.yaml
@@ -303,6 +303,9 @@ ingress:
   # be specified below under 'ingress.annotations'.
   #
   nginx: true
+
+  # -- The class name used by the 'ingress-nginx' controller if it's being used. 
+  ingressNginxClassName: nginx
   
   # -- The max body size to allow. Requests exceeding this size will result
   # in an HTTP 413 error being returned to the client.


### PR DESCRIPTION
Sometimes clusters have multiple ingress-nginx controllers with
different names, or they simply do not use the default name of
'nginx'.

This change allows the class name to be specified while still using
the built-in Helm Chart functionality of 'nginx: true' instead of
having to redefine all the annotations included with 'nginx:true'